### PR TITLE
113 link styles

### DIFF
--- a/apps/showcase-ui/jest.config.js
+++ b/apps/showcase-ui/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: '../../jest.config.js',
+  preset: '../../jest.config.js',
   coverageDirectory: '../../coverage/apps/showcase-ui',
   snapshotSerializers: [
     'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',

--- a/libs/ui/link/src/lib/link/link.component.html
+++ b/libs/ui/link/src/lib/link/link.component.html
@@ -1,6 +1,6 @@
 <a
   *ngIf="!isExternal"
-  class="c-link qa-link qa-link-internal"
+  class="c-link c-link--internal"
   [routerLink]="destination || localRoute"
   fragment="{{ fragment }}"
   tabindex="{{ tabIndex }}"
@@ -11,15 +11,14 @@
 
 <a
   *ngIf="isExternal"
-  class="c-link qa-link qa-link-external"
+  class="c-link c-link--external"
   [href]="destination"
   target="_blank"
+  rel="noopener"
   tabindex="{{ tabIndex }}"
 >
   <ng-template *ngTemplateOutlet="contentTemplate"></ng-template>
-
-  <ts-icon *ngIf="showExternalIcon"
-  >open_in_new</ts-icon>
+  <ts-icon *ngIf="showExternalIcon">open_in_new</ts-icon>
 </a>
 
 

--- a/libs/ui/link/src/lib/link/link.component.scss
+++ b/libs/ui/link/src/lib/link/link.component.scss
@@ -1,17 +1,6 @@
-@import '~@terminus/ui-styles/helpers';
-
-
-//
-// @component
-//  Link
-// @description
-//  Basic link styles.
-//
-//  NOTE: Typography/color/size should be inherited from the context.
-//
 .ts-link {
-  @include reset;
   --link-color: inherit;
+  --link-fontWeight: 400;
   display: inline-block;
 
   // Top level styles should be nested here
@@ -102,7 +91,7 @@
     background-color: var(--menu-item-backgroundColor);
     color: var(--menu-item-color);
     display: block;
-    font-weight: $type__weight--base;
+    font-weight: var(--link-fontWeight);
     padding: var(--ts-space-inset-300) var(--ts-space-inset-500);
     text-decoration: none;
     transition-duration: var(--ts-animation-time-duration-400);

--- a/specs/ui-link/link.component.spec.ts
+++ b/specs/ui-link/link.component.spec.ts
@@ -62,7 +62,7 @@ describe(`TsLinkComponent`, function() {
       component.isExternal = false;
       component.destination = ['/#'];
 
-      expect(link.classList).toContain('qa-link-internal');
+      expect(link.classList).toContain('c-link--internal');
     });
 
     describe(`fragment`, function() {
@@ -94,8 +94,9 @@ describe(`TsLinkComponent`, function() {
       fixture.detectChanges();
       link = fixture.debugElement.query(By.css('.c-link')).nativeElement;
 
-      expect(link.classList).toContain('qa-link-external');
+      expect(link.classList).toContain('c-link--external');
       expect(link.children[0].textContent).toContain('open_in_new');
+      expect(link.getAttribute('rel')).toEqual('noopener');
     });
   });
 
@@ -105,12 +106,12 @@ describe(`TsLinkComponent`, function() {
       component.isExternal = true;
       fixture.detectChanges();
       emailLink = fixture.debugElement.query(By.css('.c-link')).nativeElement;
-      expect(emailLink.classList).toContain('qa-link-external');
+      expect(emailLink.classList).toContain('c-link--external');
 
       component.destination = 'tel: 18003256789';
       fixture.detectChanges();
       link = fixture.debugElement.query(By.css('.c-link')).nativeElement;
-      expect(link.classList).toContain('qa-link-external');
+      expect(link.classList).toContain('c-link--external');
 
       const externalLink = fixture.debugElement.query(By.css('.ts-icon'));
       expect(externalLink).toBeFalsy();


### PR DESCRIPTION
- Don't rely on SCSS - use css vars instead
- Use rel noopener for external links for security
- Remove super old QA classes

Closes #113 
Closes #131 