### PR TITLE
fix: fast follow updates for LPS

### DIFF
--- a/apps/showcase-ui/src/app/components/button/button.component.ts
+++ b/apps/showcase-ui/src/app/components/button/button.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
-import { faPlus } from '@fortawesome/pro-regular-svg-icons/faPlus';
-import { faWrench } from '@fortawesome/pro-regular-svg-icons/faWrench';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
+import { faPlus } from '@fortawesome/pro-solid-svg-icons/faPlus';
+import { faWrench } from '@fortawesome/pro-solid-svg-icons/faWrench';
 
 import {
   TsButtonFormatTypes,

--- a/apps/showcase-ui/src/app/components/icon-button/icon-button.component.ts
+++ b/apps/showcase-ui/src/app/components/icon-button/icon-button.component.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
-import { faBacteria } from '@fortawesome/pro-regular-svg-icons/faBacteria';
-import { faPortalEnter } from '@fortawesome/pro-regular-svg-icons/faPortalEnter';
-import { faPortalExit } from '@fortawesome/pro-regular-svg-icons/faPortalExit';
-import { faRocketLaunch } from '@fortawesome/pro-regular-svg-icons/faRocketLaunch';
+import { faBacteria } from '@fortawesome/pro-solid-svg-icons/faBacteria';
+import { faPortalEnter } from '@fortawesome/pro-solid-svg-icons/faPortalEnter';
+import { faPortalExit } from '@fortawesome/pro-solid-svg-icons/faPortalExit';
+import { faRocketLaunch } from '@fortawesome/pro-solid-svg-icons/faRocketLaunch';
 
 
 @Component({

--- a/apps/showcase-ui/src/app/components/icon/icon.component.ts
+++ b/apps/showcase-ui/src/app/components/icon/icon.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
-import { faAmericanSignLanguageInterpreting } from '@fortawesome/pro-regular-svg-icons/faAmericanSignLanguageInterpreting';
-import { faCoffee } from '@fortawesome/pro-regular-svg-icons/faCoffee';
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
-import { faHorseSaddle } from '@fortawesome/pro-regular-svg-icons/faHorseSaddle';
-import { faPlusSquare } from '@fortawesome/pro-regular-svg-icons/faPlusSquare';
+import { faAmericanSignLanguageInterpreting } from '@fortawesome/pro-solid-svg-icons/faAmericanSignLanguageInterpreting';
+import { faCoffee } from '@fortawesome/pro-solid-svg-icons/faCoffee';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
+import { faHorseSaddle } from '@fortawesome/pro-solid-svg-icons/faHorseSaddle';
+import { faPlusSquare } from '@fortawesome/pro-solid-svg-icons/faPlusSquare';
 
 @Component({
   selector: 'demo-icon',

--- a/apps/showcase-ui/src/app/components/input/input.component.html
+++ b/apps/showcase-ui/src/app/components/input/input.component.html
@@ -73,7 +73,6 @@
       [mask]="activeMask"
       [autocomplete]="'on'"
       name="static input"
-      theme="accent"
       tsVerticalSpacing="small--0"
     ></ts-input>
 

--- a/apps/showcase-ui/src/app/components/input/input.component.ts
+++ b/apps/showcase-ui/src/app/components/input/input.component.ts
@@ -4,8 +4,8 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
-import { faAt } from '@fortawesome/pro-regular-svg-icons/faAt';
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
+import { faAt } from '@fortawesome/pro-solid-svg-icons/faAt';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
 
 import { TsValidatorsService } from '@terminus/ui-validators';
 

--- a/apps/showcase-ui/src/app/components/table/table.component.ts
+++ b/apps/showcase-ui/src/app/components/table/table.component.ts
@@ -19,9 +19,9 @@ import {
   DomSanitizer,
   SafeHtml,
 } from '@angular/platform-browser';
-import { faExternalLink } from '@fortawesome/pro-regular-svg-icons/faExternalLink';
-import { faGripLines } from '@fortawesome/pro-regular-svg-icons/faGripLines';
-import { faTable } from '@fortawesome/pro-regular-svg-icons/faTable';
+import { faExternalLink } from '@fortawesome/pro-solid-svg-icons/faExternalLink';
+import { faGripLines } from '@fortawesome/pro-solid-svg-icons/faGripLines';
+import { faTable } from '@fortawesome/pro-solid-svg-icons/faTable';
 import {
   merge,
   Observable,

--- a/apps/showcase-ui/src/app/components/tabs/tabs.component.ts
+++ b/apps/showcase-ui/src/app/components/tabs/tabs.component.ts
@@ -4,8 +4,8 @@ import {
   ViewChild,
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
-import { faQuestionCircle } from '@fortawesome/pro-regular-svg-icons/faQuestionCircle';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
+import { faQuestionCircle } from '@fortawesome/pro-solid-svg-icons/faQuestionCircle';
 import { BehaviorSubject } from 'rxjs';
 
 import { TsTabCollectionComponent } from '@terminus/ui-tabs';

--- a/apps/vr/src/app/components/button/button.component.ts
+++ b/apps/vr/src/app/components/button/button.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
-import { faPlus } from '@fortawesome/pro-regular-svg-icons/faPlus';
-import { faWrench } from '@fortawesome/pro-regular-svg-icons/faWrench';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
+import { faPlus } from '@fortawesome/pro-solid-svg-icons/faPlus';
+import { faWrench } from '@fortawesome/pro-solid-svg-icons/faWrench';
 
 @Component({
   selector: 'app-button',

--- a/libs/ui/button/CHANGELOG.md
+++ b/libs/ui/button/CHANGELOG.md
@@ -59,7 +59,7 @@ If passing in a theme, use one of the supported themes: `default|secondary|warni
 If passing in an icon, pass in a FontAwesome icon reference instead of a string name:
 
 ```typescript
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
 ...
 public home = faHome;
 ```

--- a/libs/ui/button/src/lib/button/button.component.scss
+++ b/libs/ui/button/src/lib/button/button.component.scss
@@ -23,7 +23,7 @@
   --tsb-theme-secondary-borderColor: var(--ts-color-utility-300);
   --tsb-theme-secondary-borderColor-hover: var(--ts-color-utility-500);
   --tsb-theme-secondary-borderColor-active: var(--ts-color-utility-600);
-  --tsb-theme-secondary-borderColor-focus: var(--ts-color-light);
+  --tsb-theme-secondary-borderColor-focus: var(--ts-color-utility-400);
   --tsb-theme-secondary-color: var(--ts-color-primary-500);
   --tsb-theme-secondary-color-active: var(--ts-color-primary-500);
   --tsb-theme-secondary-color-focus: var(--ts-color-primary-500);
@@ -37,7 +37,7 @@
   --tsb-theme-warning-borderColor: var(--ts-color-utility-300);
   --tsb-theme-warning-borderColor-hover: var(--ts-color-utility-500);
   --tsb-theme-warning-borderColor-active: var(--ts-color-utility-600);
-  --tsb-theme-warning-borderColor-focus: var(--ts-color-warn-100);
+  --tsb-theme-warning-borderColor-focus: var(--ts-color-utility-400);
   --tsb-theme-warning-color: var(--ts-color-warn-500);
   --tsb-theme-warning-color-active: var(--ts-color-warn-500);
   --tsb-theme-warning-color-focus: var(--ts-color-warn-500);
@@ -84,7 +84,8 @@
     border-radius: var(--ts-button-borderRadius);
     color: var(--ts-button-color);
     cursor: pointer;
-    font: var(--ts-typography-compound-body);
+    font: var(--ts-typography-compound-body2);
+    font-size: 14px;
     line-height: var(--ts-button-lineHeight);
     padding: var(--ts-button-padding);
     position: relative;

--- a/libs/ui/card/src/lib/card/card.component.ts
+++ b/libs/ui/card/src/lib/card/card.component.ts
@@ -7,7 +7,7 @@ import {
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { faLockAlt } from '@fortawesome/pro-regular-svg-icons/faLockAlt';
+import { faLockAlt } from '@fortawesome/pro-solid-svg-icons/faLockAlt';
 
 import { TsStyleThemeTypes } from '@terminus/ui-utilities';
 

--- a/libs/ui/checkbox/src/lib/checkbox/checkbox.component.html
+++ b/libs/ui/checkbox/src/lib/checkbox/checkbox.component.html
@@ -1,5 +1,6 @@
 <mat-checkbox
   class="c-checkbox qa-checkbox"
+  color="primary"
   [indeterminate]="isIndeterminate"
   [disabled]="isDisabled ? 'disabled' : null"
   [required]="isRequired ? '' : null"

--- a/libs/ui/checkbox/src/lib/checkbox/checkbox.component.scss
+++ b/libs/ui/checkbox/src/lib/checkbox/checkbox.component.scss
@@ -18,6 +18,11 @@
     border-color: var(--ts-checkbox-borderColor);
   }
 
+  .mat-checkbox-frame,
+  .mat-checkbox-background {
+    border-radius: 4px;
+  }
+
   .mat-checkbox-indeterminate,
   .mat-checkbox-checked {
     .mat-checkbox-background {

--- a/libs/ui/copy/src/lib/copy/copy.component.ts
+++ b/libs/ui/copy/src/lib/copy/copy.component.ts
@@ -9,7 +9,7 @@ import {
   ViewChildren,
   ViewEncapsulation,
 } from '@angular/core';
-import { faCopy } from '@fortawesome/pro-regular-svg-icons/faCopy';
+import { faCopy } from '@fortawesome/pro-solid-svg-icons/faCopy';
 
 import {
   TsDocumentService,

--- a/libs/ui/csv-entry/src/lib/csv-entry/csv-entry.component.ts
+++ b/libs/ui/csv-entry/src/lib/csv-entry/csv-entry.component.ts
@@ -18,7 +18,7 @@ import {
   FormGroup,
   ValidatorFn,
 } from '@angular/forms';
-import { faTrash } from '@fortawesome/pro-regular-svg-icons/faTrash';
+import { faTrash } from '@fortawesome/pro-solid-svg-icons/faTrash';
 import { debounceTime } from 'rxjs/operators';
 
 import { TsDocumentService } from '@terminus/ngx-tools/browser';

--- a/libs/ui/file-upload/src/lib/file-upload/file-upload.component.ts
+++ b/libs/ui/file-upload/src/lib/file-upload/file-upload.component.ts
@@ -20,9 +20,9 @@ import {
   FormControl,
   ValidationErrors,
 } from '@angular/forms';
-import { faFileCsv } from '@fortawesome/pro-regular-svg-icons/faFileCsv';
-import { faTimes } from '@fortawesome/pro-regular-svg-icons/faTimes';
-import { faUpload } from '@fortawesome/pro-regular-svg-icons/faUpload';
+import { faFileCsv } from '@fortawesome/pro-solid-svg-icons/faFileCsv';
+import { faTimes } from '@fortawesome/pro-solid-svg-icons/faTimes';
+import { faUpload } from '@fortawesome/pro-solid-svg-icons/faUpload';
 import { filter } from 'rxjs/operators';
 
 import { TsDocumentService } from '@terminus/ngx-tools/browser';

--- a/libs/ui/form-field/src/lib/form-field/form-field.component.scss
+++ b/libs/ui/form-field/src/lib/form-field/form-field.component.scss
@@ -3,7 +3,7 @@
 .ts-form-field {
   --formField-outlineColor-default: var(--ts-color-utility-500);
   --formField-outlineColor-default-hover: var(--ts-color-base-black);
-  --formField-outlineColor-theme: var(--ts-color-primary-500);
+  --formField-outlineColor-theme: var(--ts-color-utility-400);
   --formField-outlineColor-disabled: var(--ts-color-utility-500);
   --formField-color-disabled: var(--ts-color-utility-500);
   --formField-outline-borderRadius: var(--ts-border-radius-base);
@@ -33,6 +33,10 @@
   --formField-wrapper-paddingBottom: 1.43em;
   // The amount we offset the label from the input text in the outline appearance.
   --formField-outline-labelOffset: -.35em;
+  --ts-formField-boxShadow-color: var(--ts-color-primary-300);
+  --ts-formField-boxShadow-color-error: var(--ts-color-warn-300);
+
+  color: var(--ts-color-utility-900);
   display: block;
 
   /////////////////////////
@@ -84,28 +88,30 @@
   // Focused theme support
   &.ts-form-field--focused {
     .ts-form-field__outline--thick {
+      box-shadow: 0 0 2px 2px var(--ts-formField-boxShadow-color);
       color: var(--formField-outlineColor-theme);
     }
 
     &.ts-form-field--accent {
       .ts-form-field__outline--thick {
         --formField-outlineColor-theme: var(--ts-color-accent-500);
+        --ts-formField-boxShadow-color: var(--ts-color-accent-300);
       }
     }
 
+    &.ts-form-field--invalid,
     &.ts-form-field--warn {
       .ts-form-field__outline--thick {
         --formField-outlineColor-theme: var(--ts-color-warn-500);
+        --ts-formField-boxShadow-color: var(--ts-color-warn-300);
       }
     }
   }
 
   // NOTE: Class is repeated so that rule is specific enough to override focused accent color case.
   &.ts-form-field--invalid {
-    &.ts-form-field--invalid {
-      .ts-form-field__outline--thick {
-        --formField-outlineColor-theme: var(--ts-color-warn-500);
-      }
+    .ts-form-field__outline--thick {
+      --formField-outlineColor-theme: var(--ts-color-warn-500);
     }
   }
 
@@ -171,13 +177,12 @@
   }
 
   .ts-form-field__outline--thick {
-    color: var(--formField-outlineColor-default-hover);
+    color: var(--formField-outlineColor-theme);
     opacity: 0;
 
     .ts-form-field__outline-start,
     .ts-form-field__outline-end,
     .ts-form-field__outline-gap {
-      --formField-outline-width: var(--formField-outline-width-thick);
       transition: border-color var(--ts-animation-time-duration-300) var(--swift-ease-out-timing-function);
     }
   }
@@ -229,6 +234,7 @@
 
   .ts-form-field__prefix,
   .ts-form-field__suffix {
+    color: var(--ts-color-utility-600);
     flex: none;
     position: relative;
     top: var(--formField-outline-labelOverlap);
@@ -249,6 +255,8 @@
   // Scale down icons in the label and hint to be the same size as the text.
   .ts-form-field__subscript-wrapper,
   .ts-form-field__label-wrapper {
+    color: var(--ts-color-utility-700);
+
     .ts-icon {
       font-size: inherit;
       height: 1em;

--- a/libs/ui/icon-button/CHANGELOG.md
+++ b/libs/ui/icon-button/CHANGELOG.md
@@ -41,7 +41,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 If passing in an icon, pass in a FontAwesome icon reference instead of a string name:
 
 ```typescript
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
 ...
 public home = faHome;
 ```

--- a/libs/ui/icon-button/README.md
+++ b/libs/ui/icon-button/README.md
@@ -52,7 +52,7 @@ In your top level stylesheet, add these imports:
 Pass a valid FontAwesome icon reference:
 
 ```typescript
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
 ...
 public home = faHome;
 ```

--- a/libs/ui/icon/README.md
+++ b/libs/ui/icon/README.md
@@ -29,7 +29,7 @@
 - `@fortawesome/fontawesome-svg-core`
 - `@fortawesome/free-brands-svg-icons`
 - `@fortawesome/pro-light-svg-icons`
-- `@fortawesome/pro-regular-svg-icons`
+- `@fortawesome/pro-solid-svg-icons`
 - `@fortawesome/pro-solid-svg-icons`
 
 Use the `ng add` command to quickly install all the needed dependencies:
@@ -56,7 +56,7 @@ In your top level stylesheet, add these imports:
 Import any FontAwesome icon and pass it in:
 
 ```typescript
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
 ...
 public home = faHome;
 ```

--- a/libs/ui/input/src/lib/input/input.component.scss
+++ b/libs/ui/input/src/lib/input/input.component.scss
@@ -29,7 +29,7 @@
     }
     background: transparent;
     border: none;
-    color: currentColor;
+    color: var(--ts-color-utility-900);
     font: inherit;
     margin: 0;
     // <input> elements seem to have their height set slightly too large on Safari causing the text to

--- a/libs/ui/menu/src/lib/menu/menu.component.ts
+++ b/libs/ui/menu/src/lib/menu/menu.component.ts
@@ -11,8 +11,8 @@ import {
 } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { faAngleDown } from '@fortawesome/pro-regular-svg-icons/faAngleDown';
-import { faEllipsisV } from '@fortawesome/pro-regular-svg-icons/faEllipsisV';
+import { faAngleDown } from '@fortawesome/pro-solid-svg-icons/faAngleDown';
+import { faEllipsisV } from '@fortawesome/pro-solid-svg-icons/faEllipsisV';
 
 import {
   TsButtonFormatTypes,

--- a/libs/ui/navigation/src/lib/nav/navigation.component.ts
+++ b/libs/ui/navigation/src/lib/nav/navigation.component.ts
@@ -14,7 +14,7 @@ import {
   ViewChildren,
   ViewEncapsulation,
 } from '@angular/core';
-import { faAngleDown } from '@fortawesome/pro-regular-svg-icons/faAngleDown';
+import { faAngleDown } from '@fortawesome/pro-solid-svg-icons/faAngleDown';
 import { BehaviorSubject } from 'rxjs';
 
 import { groupBy } from '@terminus/ngx-tools/utilities';

--- a/libs/ui/paginator/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/paginator/src/lib/paginator/paginator.component.ts
@@ -13,10 +13,10 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { faAngleDoubleLeft } from '@fortawesome/pro-regular-svg-icons/faAngleDoubleLeft';
-import { faAngleDoubleRight } from '@fortawesome/pro-regular-svg-icons/faAngleDoubleRight';
-import { faAngleLeft } from '@fortawesome/pro-regular-svg-icons/faAngleLeft';
-import { faAngleRight } from '@fortawesome/pro-regular-svg-icons/faAngleRight';
+import { faAngleDoubleLeft } from '@fortawesome/pro-solid-svg-icons/faAngleDoubleLeft';
+import { faAngleDoubleRight } from '@fortawesome/pro-solid-svg-icons/faAngleDoubleRight';
+import { faAngleLeft } from '@fortawesome/pro-solid-svg-icons/faAngleLeft';
+import { faAngleRight } from '@fortawesome/pro-solid-svg-icons/faAngleRight';
 
 import { coerceNumberProperty } from '@terminus/ngx-tools/coercion';
 import { inputHasChanged } from '@terminus/ngx-tools/utilities';

--- a/libs/ui/radio-group/src/lib/group/radio-group.component.ts
+++ b/libs/ui/radio-group/src/lib/group/radio-group.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { MatRadioChange } from '@angular/material/radio';
 import { DomSanitizer } from '@angular/platform-browser';
-import { faCheck } from '@fortawesome/pro-regular-svg-icons/faCheck';
+import { faCheck } from '@fortawesome/pro-solid-svg-icons/faCheck';
 
 import { isFunction } from '@terminus/ngx-tools/type-guards';
 import {

--- a/libs/ui/search/src/lib/search/search.component.ts
+++ b/libs/ui/search/src/lib/search/search.component.ts
@@ -13,7 +13,7 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
-import { faSearch } from '@fortawesome/pro-regular-svg-icons/faSearch';
+import { faSearch } from '@fortawesome/pro-solid-svg-icons/faSearch';
 
 import { debounce } from '@terminus/ngx-tools/utilities';
 import {

--- a/libs/ui/selection-list/src/lib/selection-list/selection-list.component.scss
+++ b/libs/ui/selection-list/src/lib/selection-list/selection-list.component.scss
@@ -51,6 +51,7 @@
   position: relative;
 
   > .ts-icon {
+    color: var(--ts-color-utility-600);
     position: absolute;
     right: 0;
     top: 50%;
@@ -63,7 +64,7 @@
   --fake-margin: 3px;
   background: transparent;
   border: none;
-  color: currentColor;
+  color: var(--ts-color-utility-900);
   display: inline-block;
   font: inherit;
   margin-bottom: var(--fake-margin);

--- a/libs/ui/selection-list/src/lib/selection-list/selection-list.component.ts
+++ b/libs/ui/selection-list/src/lib/selection-list/selection-list.component.ts
@@ -21,7 +21,8 @@ import {
   FormControl,
   NgControl,
 } from '@angular/forms';
-import { faAngleDown } from '@fortawesome/pro-regular-svg-icons/faAngleDown';
+import { faAngleDown } from '@fortawesome/pro-solid-svg-icons/faAngleDown';
+import { faCaretDown } from '@fortawesome/pro-solid-svg-icons/faCaretDown';
 import {
   BehaviorSubject,
   of,
@@ -156,7 +157,7 @@ export class TsSelectionListComponent implements
   /**
    * Define the dropdown arrow
    */
-  public iconArrow = faAngleDown;
+  public iconArrow = faCaretDown;
 
   /**
    * Define the internal FormControl

--- a/specs/ui-button/button.component.spec.ts
+++ b/specs/ui-button/button.component.spec.ts
@@ -7,8 +7,8 @@ import {
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
-import { faSearch } from '@fortawesome/pro-regular-svg-icons/faSearch';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
+import { faSearch } from '@fortawesome/pro-solid-svg-icons/faSearch';
 
 import {
   createComponent,

--- a/specs/ui-icon/icon.component.spec.ts
+++ b/specs/ui-icon/icon.component.spec.ts
@@ -7,7 +7,7 @@ import {
   TestBed,
   TestModuleMetadata,
 } from '@angular/core/testing';
-import { faHome } from '@fortawesome/pro-regular-svg-icons/faHome';
+import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
 
 import { configureTestBedWithoutReset } from '@terminus/ngx-tools/testing';
 import {


### PR DESCRIPTION
All

- Use the solid weight of Font Awesome 5 for icons


Button

- secondary and warning buttons, on focus, border grey 40
- font-weight: 500
- font-size: 14px

Checkbox

- set border radius to 4

Inputs/SelectionLists/etc

- change color
- add shadow focus
- overwrite border themes to just be gray
- change icon color
- change label color

SelectionList

- change icon to solid caret