### PR TITLE
chore(CI): update method of tag update

### DIFF
--- a/tools/ci/update-release-tag.sh
+++ b/tools/ci/update-release-tag.sh
@@ -15,14 +15,16 @@ echo "Delete local tag.."
 git tag -d last-successful-release
 echo "Delete remote tag.."
 git push --delete origin last-successful-release
+git push origin release :refs/tags/last-successful-release
 
 # Enable exit on non 0
 set -e
 
 echo "Creating new release tag.."
-git tag -a last-successful-release -m "CI: Tagged as last successful release"
+git tag -fa last-successful-release -m "CI: Tagged as last successful release"
 echo "Push new tag.."
-git push origin last-successful-release
+git push origin release --tags
+
 
 
 


### PR DESCRIPTION
Something is not correct with our current version. The script is working, but the tag seems to still be pointing to the old commit. So when we determine how many commits since last successful tag, the number is wildly incorrect.

Hopefully this fixes that.