### PR TITLE
chore(CI): new tag update method

### DIFF
--- a/tools/ci/update-release-tag.sh
+++ b/tools/ci/update-release-tag.sh
@@ -9,25 +9,20 @@
 # Disable exit on non 0
 set +e
 
-echo "Fetch all tags.."
-git fetch -p origin
+TAG="last-successful-release"
+LAST_SHA=$(git rev-parse HEAD)
+echo "Tag: $TAG"
+echo "SHA: $LAST_SHA"
+
 echo "Delete local tag.."
-git tag -d last-successful-release
+git tag -d "$TAG"
 echo "Delete remote tag.."
-git push --delete origin last-successful-release
-git push origin release :refs/tags/last-successful-release
+git push origin :refs/tags/"$TAG"
 
 # Enable exit on non 0
 set -e
 
 echo "Creating new release tag.."
-git tag -fa last-successful-release -m "CI: Tagged as last successful release"
+git tag "$TAG" "$LAST_SHA" -m "CI: Tagged as last successful release"
 echo "Push new tag.."
-git push origin release --tags
-
-
-
-
-
-
-
+git push origin "$TAG"


### PR DESCRIPTION
New CI tag is still pointing to original commit. This is another attempt to remedy that.