### PR TITLE
fix(TsLoginForm): add TsDatePipe in list of providers

### DIFF
--- a/libs/ui/login-form/src/lib/ui-login-form.module.ts
+++ b/libs/ui/login-form/src/lib/ui-login-form.module.ts
@@ -7,6 +7,7 @@ import { TsButtonModule } from '@terminus/ui-button';
 import { TsCheckboxModule } from '@terminus/ui-checkbox';
 import { TsInputModule } from '@terminus/ui-input';
 import { TsLinkModule } from '@terminus/ui-link';
+import { TsDatePipe } from '@terminus/ui-pipes';
 import { TsSpacingModule } from '@terminus/ui-spacing';
 import { TsValidatorsService } from '@terminus/ui-validators';
 
@@ -26,7 +27,10 @@ export * from './form/login-form.component';
     TsLinkModule,
     TsSpacingModule,
   ],
-  providers: [TsValidatorsService],
+  providers: [
+    TsValidatorsService,
+    TsDatePipe,
+  ],
   exports: [TsLoginFormComponent],
   declarations: [TsLoginFormComponent],
 })


### PR DESCRIPTION
When an app using TsLoginForm module, it spits out Null Injector error:

![image](https://user-images.githubusercontent.com/377552/91775920-558d7600-ebba-11ea-9c57-da5ca7da2e61.png)

TsInputModule list TsDatePipe as one of the providers, but it's not listed in TsLoginFormModule. Once this added, the Null Injector error went away.