### PR TITLE
Update to a valid codecov.yml

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -10,7 +10,8 @@ coverage:
     project:
       default: off
       unit:
-        flags: unit
+        flags:
+          - unit
 
 comment:
   layout: "reach, diff, flags, files"


### PR DESCRIPTION
Looks like this was an invalid yaml, and thus carryforward flags were not working. In the future, you can always validate via [these steps](https://docs.codecov.io/docs/codecov-yaml#validate-your-repository-yaml).