### PR TITLE
fix(ESLintConfig): update duplicate import rule to allow type imports

### DIFF
--- a/libs/eslint-config-frontend/src/lib/rules.js
+++ b/libs/eslint-config-frontend/src/lib/rules.js
@@ -322,7 +322,7 @@ module.exports = {
 
     // Using a single import statement per module will make the code clearer because you can see everything being imported from that module
     // on one line.
-    'no-duplicate-imports': SEVERITY,
+    'import/no-duplicates': SEVERITY,
 
     // If an if block contains a return statement, the else block becomes unnecessary.
     'no-else-return': SEVERITY,


### PR DESCRIPTION
Closes #408 

BREAKING CHANGE: `no-duplicate-imports` is now named `import/no-duplicates`. Any ESLint disable comments or rule overrides must be updated.

This change allows consumers to define: 

```typescript
import { Foo } from ./foo`;
import type { FooType } from ./foo
```

without trigging the duplicate import error.


### Migration notes for 4.0.0

Find any reference to `no-duplicate-imports` and change to `import/no-duplicates`.
