### PR TITLE
Abbreviate number trailing zero

### DIFF
--- a/libs/fe-utilities/src/lib/general/README.md
+++ b/libs/fe-utilities/src/lib/general/README.md
@@ -35,7 +35,6 @@ A collection of useful utilities.
 - [`toCamelCase`](#tocamelcase)
 - [`untilComponentDestroyed`](#untilcomponentdestroyed)
 - [`updateControlOnInputChanges`](#updatecontroloninputchanges)
-- [`VERSION`](#version)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -570,17 +569,4 @@ import { updateControlOnInputChanges } from '@terminus/fe-utilities';
     updateControlOnInputChanges(changes, 'myInput', this.myFormControl));
   }
 ...
-```
-
-## `VERSION`
-
-An object containing the current version of the library.
-
-```typescript
-import { VERSION } from '@terminus/fe-utilities';
-
-VERSION.full  // Returns: 1.2.3
-VERSION.major // Returns: 1
-VERSION.minor // Returns: 2
-VERSION.patch // Returns: 3
 ```

--- a/libs/fe-utilities/src/lib/general/README.md
+++ b/libs/fe-utilities/src/lib/general/README.md
@@ -47,7 +47,11 @@ A utility to abbreviate numbers.
 import { abbreviateNumber } from '@terminus/fe-utilities';
 
 const input1 = 1234;
-return abbreviateNumber(input1, 1); // expect to get 1.2K
+abbreviateNumber(input1, '1'); // expect to get `1.2K`
+
+const input2 = 1200;
+abbreviateNumber(input2, 3);        // expect to get `1.200K`
+abbreviateNumber(input2, 3, false); // expect to get `1.2K`
 ```
 
 ## `applyMixins`

--- a/libs/fe-utilities/src/lib/general/abbreviate-number.ts
+++ b/libs/fe-utilities/src/lib/general/abbreviate-number.ts
@@ -5,12 +5,15 @@ import { coerceNumberProperty } from '../coercion/number-property';
  *
  * @param value - The number to be abbreviated.
  * @param decimalPlace - The decimals users define for final abbreviated number. Default to 1.
+ * @param allowTrailingZeros - Whether trailing zeros should be stripped
  * @returns The abbreviated number
  *
  * @example
- * abbreviateNumber(1234, '1')              // Returns: '1.2K'
+ * abbreviateNumber(1264)           // Returns: '1.3K'
+ * abbreviateNumber(1200, 3)        // Returns: '1.200K'
+ * abbreviateNumber(1200, 3, false) // Returns: '1.2K'
  */
-export function abbreviateNumber(value: number | string | null, decimalPlace = 1): string {
+export function abbreviateNumber(value: number | string | null, decimalPlace = 1, allowTrailingZeros = true): string {
   const input = coerceNumberProperty(value);
   const SCALE_NUMBER = 3;
   const MATH_POWER = 10;
@@ -36,8 +39,7 @@ export function abbreviateNumber(value: number | string | null, decimalPlace = 1
     'B',
     'T',
   ][(baseNumberAndExponent[1] - scaleLevel) / SCALE_NUMBER];
-
   const newNumber = baseNumberAndExponent[0].toFixed(decimalPlace).toString();
-  return newNumber + calculatedScale;
+  return (allowTrailingZeros ? newNumber : parseFloat(newNumber).toString()) + calculatedScale;
 }
 

--- a/specs/fe-utilities/abbreviate-number.spec.ts
+++ b/specs/fe-utilities/abbreviate-number.spec.ts
@@ -1,26 +1,36 @@
 import { abbreviateNumber } from '@terminus/fe-utilities';
 
 describe(`abbreviateNumber`, function() {
-  test(`should parse to the lowest level specified`, () => {
-    const input1 = 1234;
-    const input2 = 1234567;
-    const input3 = 1234567890;
-    const input4 = 1234567890123;
-    const input5 = 1200;
-    const input6 = 450;
-    const input7 = 123456;
-    const input8 = '123456';
-    expect(abbreviateNumber(null)).toEqual('');
-    expect(abbreviateNumber('')).toEqual('');
-    expect(abbreviateNumber(void 0)).toEqual('');
-    expect(abbreviateNumber(input1)).toEqual('1.2K');
-    expect(abbreviateNumber(input1, 1)).toEqual('1.2K');
-    expect(abbreviateNumber(input2, 1)).toEqual('1.2M');
-    expect(abbreviateNumber(input3, 1)).toEqual('1.2B');
-    expect(abbreviateNumber(input4, 2)).toEqual('1.23T');
-    expect(abbreviateNumber(input5, 3)).toEqual('1.200K');
-    expect(abbreviateNumber(input6, 1)).toEqual('450');
-    expect(abbreviateNumber(input7, 2)).toEqual('123.46K');
-    expect(abbreviateNumber(input8, 2)).toEqual('123.46K');
+  const input1 = 1234;
+  const input2 = 1234567;
+  const input3 = 1234567890;
+  const input4 = 1234567890123;
+  const input5 = 1200;
+  const input6 = 450;
+  const input7 = 123456;
+  const input8 = '123456';
+
+  describe(`allowTrailingZeros`, () => {
+    test(`should parse to the lowest level specified`, () => {
+      expect(abbreviateNumber(null)).toEqual('');
+      expect(abbreviateNumber('')).toEqual('');
+      expect(abbreviateNumber(void 0)).toEqual('');
+      expect(abbreviateNumber(input1)).toEqual('1.2K');
+      expect(abbreviateNumber(input1, 1)).toEqual('1.2K');
+      expect(abbreviateNumber(input2, 1)).toEqual('1.2M');
+      expect(abbreviateNumber(input3, 1)).toEqual('1.2B');
+      expect(abbreviateNumber(input4, 2)).toEqual('1.23T');
+      expect(abbreviateNumber(input5, 3)).toEqual('1.200K');
+      expect(abbreviateNumber(input6, 1)).toEqual('450');
+      expect(abbreviateNumber(input7, 2)).toEqual('123.46K');
+      expect(abbreviateNumber(input8, 2)).toEqual('123.46K');
+      expect(abbreviateNumber(input5, 3, false)).toEqual('1.2K');
+    });
+  });
+
+  describe(`without trailing zeros`, () => {
+    test(`should remove trailing zeros`, () => {
+      expect(abbreviateNumber(input5, 3, false)).toEqual('1.2K');
+    });
   });
 });

--- a/specs/fe-utilities/is-array-of-type.spec.ts
+++ b/specs/fe-utilities/is-array-of-type.spec.ts
@@ -28,4 +28,9 @@ describe(`isArrayOfType`, function() {
     expect(isArrayOfType(mixedArray, isNumber)).toEqual(false);
     expect(isArrayOfType(mixedArray, isString)).toEqual(false);
   });
+
+  test(`should return false if no guard is passed in`, () => {
+    expect(isArrayOfType(numbersArray1, undefined)).toEqual(false);
+    expect(isArrayOfType(numbersArray1, 'test' as any)).toEqual(false);
+  });
 });


### PR DESCRIPTION
- support trimming zeros for abbreviate number, closes #221
- bump is array of type test coverage to 100%
- remove outdated doc section