### PR TITLE
441 new button styles

### DIFF
--- a/apps/ui-storybook/.storybook/main.js
+++ b/apps/ui-storybook/.storybook/main.js
@@ -4,6 +4,7 @@ module.exports = {
   stories: [
     '../../../libs/**/*.stories.@(js|ts|mdx)',
     '../src/**/*.stories.@(js|ts|mdx)',
+    '../../../stories/**/*.stories.@(js|ts|mdx)',
   ],
   addons: [
     '@storybook/addon-essentials',

--- a/libs/ui/button/src/lib/button/button.component.html
+++ b/libs/ui/button/src/lib/button/button.component.html
@@ -2,7 +2,8 @@
   class="c-button c-button--{{ theme }} c-button--{{ format }}"
   [ngClass]="{
     'c-button--collapsed': isCollapsed,
-    'c-button--progress': showProgress && !isDisabled
+    'c-button--progress': showProgress && !isDisabled,
+    'c-button--small': isSmall
   }"
   [attr.aria-label]="actionName"
   [attr.id]="id"
@@ -19,7 +20,8 @@
   ></ts-icon>
 
   <span class="c-button__content">
-    <ng-content></ng-content>
+    <span class="c-button__content-ng-content"><ng-content></ng-content></span>
+    <span class="c-button__content-input">{{ textContent }}</span>
   </span>
 
   <mat-progress-spinner

--- a/libs/ui/button/src/lib/button/button.component.scss
+++ b/libs/ui/button/src/lib/button/button.component.scss
@@ -45,6 +45,25 @@
   --tsb-theme-warning-color-active: var(--ts-color-warn-500);
   --tsb-theme-warning-color-focus: var(--ts-color-warn-500);
   --tsb-theme-warning-boxShadow-color-focus: var(--ts-color-warn-300);
+  // ALTERNATE-PRIMARY
+  $green-500: #2d8734;
+  $green-300: lighten($green-500, 8);
+  $green-700: darken($green-500, 8);
+  $green-900: darken($green-500, 16);
+  --tsb-theme-alternate-primary-backgroundColor: #{$green-500};
+  --tsb-theme-alternate-primary-backgroundColor-hover: #{$green-700};
+  --tsb-theme-alternate-primary-backgroundColor-active: #{$green-900};
+  --tsb-theme-alternate-primary-backgroundColor-focus: #{$green-500};
+  --tsb-theme-alternate-primary-backgroundColor-disabled: var(--ts-color-utility-300);
+  --tsb-theme-alternate-primary-borderColor: #2d8734;
+  --tsb-theme-alternate-primary-borderColor-hover: #{$green-700};
+  --tsb-theme-alternate-primary-borderColor-active: #{$green-900};
+  --tsb-theme-alternate-primary-borderColor-focus: #{$green-500};
+  --tsb-theme-alternate-primary-borderColor-disabled: var(--ts-color-utility-300);
+  --tsb-theme-alternate-primary-color: var(--ts-color-light);
+  --tsb-theme-alternate-primary-color-active: var(--ts-color-light);
+  --tsb-theme-alternate-primary-color-focus: var(--ts-color-light);
+  --tsb-theme-alternate-primary-boxShadow-color-focus: #{$green-300};
 
   // Variables to overwrite with theme values
   --tsb-color: var(--ts-color-light);
@@ -80,6 +99,9 @@
   --tsb-icon-transitionDuration-expand: calc(var(--tsb-icon-transitionDuration-collapse) - 100ms);
   --tsb-label-transitionDuration: calc(var(--tsb-icon-transitionDuration-expand) - 100ms);
   --tsb-maxWidth-transition: max-width var(--tsb-content-transitionDuration) var(--tsb-animationEasing);
+  --tsb-maxWidth-hover-transition: max-width calc(var(--tsb-content-transitionDuration) + 100ms) ease-in-out;
+  --tsb-padding-expand-transition: padding calc(var(--tsb-content-transitionDuration) - 300ms) var(--ts-animation-easing-ease) var(--ts-animation-time-delay-200);
+  --tsb-icon-expand-transition: margin-right calc(var(--tsb-content-transitionDuration) - 400ms) var(--ts-animation-easing-easeOut) var(--ts-animation-time-delay-100);
   --tsb-icon-transition: transform var(--tsb-icon-transitionDuration-expand) var(--tsb-animationEasing);
   --tsb-spinner-transition: opacity var(--tsb-label-transitionDuration) var(--tsb-animationEasing);
   --tsb-icon-collapsed-transitionDelay: 150ms;
@@ -117,7 +139,7 @@
       outline: none;
     }
 
-    $themes: default secondary warning;
+    $themes: default secondary warning alternate-primary;
     @each $theme in $themes {
       &--#{$theme} {
         --tsb-boxShadow-color: var(--tsb-theme-#{$theme}-boxShadow-color-focus);
@@ -159,6 +181,17 @@
       margin-right: var(--tsb-icon-horizontal-adjustment);
     }
 
+    &__content {
+      // If nothing is passed to <ng-content>, we fall back to the @Input value
+      .c-button__content-ng-content {
+        &:not(:empty) {
+          + .c-button__content-input {
+            display: none;
+          }
+        }
+      }
+    }
+
     // Target any icon inside a button
     // Adjust icon vertical layout
     .c-icon {
@@ -190,6 +223,16 @@
       padding-right: var(--tsb-padding-right-progress);
     }
 
+    &--small {
+      font-size: 13px;
+      line-height: 14px;
+      padding: 4px 8px;
+
+      .ts-icon {
+        transform: scale(.84);
+      }
+    }
+
     // COLLAPSIBLE
     &--collapsible {
       border-radius: var(--tsb-borderRadius-collapsible);
@@ -201,12 +244,12 @@
           &:not(:focus) {
             padding: var(--tsb-padding-collapsed);
             // Custom transition with delay needed to remove 'jump' during collapse
-            transition: padding 200ms ease 200ms;
+            transition: var(--tsb-padding-expand-transition);
 
             .ts-icon {
               margin-right: 0;
               // Custom transition with delay needed to remove 'jump' during collapse
-              transition: margin-right 100ms ease-out 100ms;
+              transition: var(--tsb-icon-expand-transition);
             }
 
             .c-icon {
@@ -227,6 +270,10 @@
       &.c-button--collapsed {
         &:hover,
         &:focus {
+          .c-button__content {
+            transition: var(--tsb-maxWidth-hover-transition);
+          }
+
           .c-icon {
             margin-left: var(--tsb-collapsible-first-icon-adjustment);
             transition-delay: var(--tsb-icon-collapsed-hover-transitionDelay);

--- a/specs/ui-button/button.component.spec.ts
+++ b/specs/ui-button/button.component.spec.ts
@@ -1,328 +1,183 @@
+import { fakeAsync } from '@angular/core/testing';
+import { Spectator } from '@ngneat/spectator';
 import {
-  Component,
-  OnDestroy,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
-import { ComponentFixture } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
-import { faSearch } from '@fortawesome/pro-solid-svg-icons/faSearch';
+  createComponentFactory,
+  createHostFactory,
+  SpectatorHost,
+} from '@ngneat/spectator/jest';
 
-import {
-  createComponent,
-  createMouseEvent,
-} from '@terminus/fe-testing';
 import {
   TsButtonModule,
   TsButtonComponent,
-  TsButtonThemeTypes,
-  TsButtonFormatTypes,
 } from '@terminus/ui-button';
 
-@Component({
-  template: `
-    <ts-button
-      [isDisabled]="disabled"
-      [showProgress]="showProgress"
-      [collapsed]="collapsed"
-      [icon]="icon"
-      [id]="myId"
-      [format]="format"
-      [theme]="theme"
-      (clicked)="clicked($event)"
-    >Click Me!</ts-button>
-  `,
-})
-class TestHostComponent implements OnInit, OnDestroy {
-  disabled!: boolean;
-  collapsed!: boolean;
-  showProgress!: boolean;
-  collapseDelay!: number | undefined;
-  format!: TsButtonFormatTypes;
-  icon!: IconProp | undefined;
-  theme!: TsButtonThemeTypes;
-  myId = 'foo';
-
-  @ViewChild(TsButtonComponent, { static: true })
-  buttonComponent!: TsButtonComponent;
-
-  changed = jest.fn();
-  clicked = jest.fn();
-  COLLAPSE_DEFAULT_DELAY = undefined;
-  ngOnInit() { }
-  ngOnDestroy() { }
-}
-
-describe(`TsButtonComponent`, function() {
-  let component: TestHostComponent;
-  let fixture: ComponentFixture<TestHostComponent>;
-  let button: HTMLButtonElement;
-  let buttonComponent: TsButtonComponent;
-
-  beforeEach(() => {
-    fixture = createComponent(TestHostComponent, [], [TsButtonModule]);
-    component = fixture.componentInstance;
-    buttonComponent = component.buttonComponent;
-    fixture.detectChanges();
-    button = fixture.debugElement.query(By.css('.c-button')).nativeElement as HTMLButtonElement;
-  });
-
-  describe(`isDisabled`, () => {
-    test(`should not have button disabled`, () => {
-      component.disabled = false;
-      fixture.detectChanges();
-      expect(buttonComponent.isDisabled).toEqual(false);
-      expect(button.disabled).toEqual(false);
-      button.click();
-      expect(component.clicked).toHaveBeenCalled();
+describe(`TsButtonComponent`, () => {
+  describe(`Basic Setup`, () => {
+    let spectator: Spectator<TsButtonComponent>;
+    let rootElement: HTMLElement;
+    const createComponent = createComponentFactory({
+      component: TsButtonComponent,
+      imports: [TsButtonModule],
+      declareComponent: false,
     });
-
-    test(`should have button disabled`, () => {
-      component.disabled = true;
-      fixture.detectChanges();
-      expect(buttonComponent.isDisabled).toEqual(true);
-      expect(button.disabled).toEqual(true);
-      expect(component.clicked).not.toHaveBeenCalled();
-    });
-  });
-
-  test(`click`, () => {
-    component.buttonComponent.clicked.emit = jest.fn();
-    button.click();
-    expect(buttonComponent.clicked.emit).toHaveBeenCalled();
-  });
-
-  describe(`showProgress`, () => {
-    test(`should set disabled attribute if showProgress is true`, () => {
-      component.showProgress = true;
-      fixture.detectChanges();
-      button = fixture.debugElement.query(By.css('.c-button')).nativeElement as HTMLButtonElement;
-      expect(buttonComponent.showProgress).toEqual(true);
-      expect(button.getAttribute('disabled')).toEqual('');
-    });
-
-    test(`should not set disabled if showProgress and disabled are false`, () => {
-      component.showProgress = false;
-      component.disabled = false;
-      fixture.detectChanges();
-      expect(buttonComponent.showProgress).toEqual(false);
-      expect(button.getAttribute('disabled')).toEqual(null);
-    });
-  });
-
-  describe(`when collapsed is true`, function() {
-    test(`should have button collapsed class set`, function() {
-      component.collapsed = true;
-      fixture.detectChanges();
-      expect(buttonComponent.isCollapsed).toEqual(true);
-      expect(button.classList).toContain('c-button--collapsed');
-    });
-  });
-
-  describe(`when format === collapsible`, function() {
-    test(`should set isCollapsed to false if a delay is set and the value is FALSE`, () => {
-      buttonComponent['collapseWithDelay'] = jest.fn();
-      buttonComponent.collapseDelay = 400;
-      buttonComponent.collapsed = false;
-      fixture.detectChanges();
-
-      expect(buttonComponent['collapseWithDelay']).toHaveBeenCalled();
-      expect(buttonComponent.isCollapsed).toEqual(false);
-      expect(button.classList).not.toContain('c-button--collapsed');
-    });
-
-    test(`should not call collapseWithDelay if no delay is set and the value is FALSE`, () => {
-      component['collapseWithDelay'] = jest.fn();
-      component.collapsed = false;
-
-      expect(component['collapseWithDelay']).not.toHaveBeenCalled();
-      expect(button.classList).not.toContain('c-button--collapsed');
-    });
-
-    test(`should not call collapseWithDelay if delay is set and the value is TRUE`, () => {
-      component['collapseWithDelay'] = jest.fn();
-      component.collapseDelay = 400;
-      component.collapsed = true;
-
-      expect(component['collapseWithDelay']).not.toHaveBeenCalled();
-      expect(button.classList).not.toContain('c-button--collapsed');
-    });
-  });
-
-  describe(`when format !== collapsible`, () => {
-    test(`should not call collapseWithDelay if the type is not collapsible`, () => {
-      component['collapseWithDelay'] = jest.fn();
-      component.buttonComponent.format = 'filled';
-      component.collapsed = false;
-
-      expect(component['collapseWithDelay']).not.toHaveBeenCalled();
-      expect(button.classList).not.toContain('c-button--collapsed');
-    });
-  });
-
-  describe(`set format`, () => {
-    describe(`when format === collapsible`, () => {
-      test(`should set the collapseDelay to default if unset`, () => {
-        buttonComponent.format = 'collapsible';
-
-        expect(component.collapseDelay).toEqual(component.COLLAPSE_DEFAULT_DELAY);
-      });
-
-      test(`should not set the collapseDelay to default if a value is passed in`, () => {
-        component.collapseDelay = 1000;
-        component.format = 'collapsible';
-        fixture.detectChanges();
-
-        expect(component.collapseDelay).toEqual(1000);
-        expect(button.classList).toContain('c-button--collapsible');
-      });
-    });
-
-    describe('when format !== collapsible', function() {
-      test(`should remove any existing collapseDelay`, () => {
-        buttonComponent.collapseDelay = 400;
-        buttonComponent.format = 'filled';
-        fixture.detectChanges();
-
-        expect(buttonComponent.collapseDelay).toBeUndefined();
-      });
-    });
-  });
-
-  describe(`set theme`, () => {
-    test(`should set a custom theme`, () => {
-      component.theme = 'secondary';
-      fixture.detectChanges();
-      expect(button.classList).not.toContain('c-button--default');
-      expect(button.classList).toContain('c-button--secondary');
-    });
-
-    test(`should not update class if no value is passed in`, () => {
-      component.theme = null as any;
-      fixture.detectChanges();
-      expect(button.classList).toContain('c-button--default');
-      expect(button.classList).not.toContain('c-button--secondary');
-    });
-  });
-
-  describe(`ngOnInit()`, function() {
-    test(`should call collapseWithDelay if collapseDelay is set`, () => {
-      jest.useFakeTimers();
-      component.format = 'collapsible';
-      component.icon = faSearch;
-      component.collapseDelay = 500;
-      fixture.detectChanges();
-      buttonComponent.ngOnInit();
-      jest.advanceTimersByTime(6000);
-      fixture.detectChanges();
-
-      expect(button.classList).toContain('c-button--collapsed');
-      jest.runAllTimers();
-    });
-
-    test(`should call not collapseWithDelay if collapseDelay is not set`, () => {
-      buttonComponent['collapseWithDelay'] = jest.fn();
-      buttonComponent.collapseDelay = undefined;
-      buttonComponent.ngOnInit();
-
-      expect(buttonComponent['collapseWithDelay']).not.toHaveBeenCalled();
-      expect(button.classList).not.toContain('c-button--collapsible');
-    });
-
-    describe(`when format === collapsible`, () => {
-      beforeEach(() => {
-        buttonComponent.format = 'collapsible';
-        buttonComponent['collapseWithDelay'] = jest.fn();
-        buttonComponent.collapseDelay = 500;
-      });
-
-      test(`should throw an error if the format is collapsible and no icon is set`, () => {
-        expect(() => {
-          buttonComponent.ngOnInit();
-        }).toThrow();
-      });
-
-      test(`should not throw an error if the format is collapsible and there is an icon set`, () => {
-        component.icon = faHome;
-
-        expect(() => {
-          component.ngOnInit();
-        }).not.toThrow();
-        expect(button.classList).not.toContain('c-button__icon');
-      });
-    });
-  });
-
-  describe(`ngOnDestroy()`, () => {
-    beforeEach(() => {
-      buttonComponent.format = 'collapsible';
-      buttonComponent.icon = faHome;
-      buttonComponent['changeDetectorRef'].detectChanges = jest.fn();
-      buttonComponent['windowService'].nativeWindow.clearTimeout = jest.fn();
-      buttonComponent['windowService'].nativeWindow.setTimeout = jest.fn().mockReturnValue(123);
-    });
-
-    test(`should clear any existing timeouts`, () => {
-      buttonComponent.ngOnInit();
-      expect(buttonComponent['collapseTimeoutId']).toEqual(123);
-
-      buttonComponent.ngOnDestroy();
-      expect(buttonComponent['windowService'].nativeWindow.clearTimeout).toHaveBeenCalledWith(123);
-    });
-  });
-
-  describe(`clickedButton()`, () => {
-    let mouseEvent: MouseEvent;
 
     beforeEach(() => {
-      buttonComponent.clicked.emit = jest.fn();
-      mouseEvent = createMouseEvent('click');
+      spectator = createComponent({
+        props: {
+          textContent: 'FooBar',
+        },
+      });
+      rootElement = spectator.component.elementRef.nativeElement;
     });
 
-    test(`should emit the click when interceptClick is false`, () => {
-      buttonComponent.clickedButton(mouseEvent);
-      expect(buttonComponent.clicked.emit).toHaveBeenCalledWith(mouseEvent);
+    test(`should exist`, () => {
+      expect(spectator.query('button')).toHaveClass('c-button');
     });
 
-    test(`should not emit the click when interceptClick is true`, () => {
-      buttonComponent.interceptClick = true;
-      buttonComponent.clickedButton(mouseEvent);
+    describe(`theme`, () => {
+      test(`should reflect the theme as a class`, () => {
+        expect.assertions(4);
+        expect(spectator.query('button')).toHaveClass('c-button--default');
+        spectator.setInput('theme', 'secondary');
+        expect(spectator.query('button')).toHaveClass('c-button--secondary');
+        spectator.setInput('theme', 'warning');
+        expect(spectator.query('button')).toHaveClass('c-button--warning');
+        spectator.setInput('theme', 'alternate-primary');
+        expect(spectator.query('button')).toHaveClass('c-button--alternate-primary');
+      });
 
-      expect(buttonComponent.clicked.emit).not.toHaveBeenCalledWith();
-      expect(buttonComponent.originalClickEvent).toEqual(mouseEvent);
+      test(`should fallback to the default theme`, () => {
+        spectator.setInput('theme', 'secondary');
+        expect(spectator.query('button')).toHaveClass('c-button--secondary');
+        spectator.setInput('theme', undefined);
+        expect(spectator.query('button')).toHaveClass('c-button--default');
+      });
+    });
+
+    test(`should default to enabled and allow setting to disabled`, () => {
+      expect(spectator.query('button')).not.toBeDisabled();
+      spectator.setInput('isDisabled', true);
+      expect(spectator.query('button')).toBeDisabled();
+    });
+
+    describe(`format`, () => {
+      test(`should reflect the format as a class`, () => {
+        expect(spectator.query('button')).toHaveClass('c-button--filled');
+        spectator.setInput('format', 'collapsible');
+        expect(spectator.query('button')).toHaveClass('c-button--collapsible');
+      });
+
+      test(`should default to 'filled' format if nothing is passed in`, () => {
+        spectator.setInput('format', 'collapsible');
+        expect(spectator.component.format).toEqual('collapsible');
+        spectator.setInput('format', undefined);
+        expect(spectator.component.format).toEqual('filled');
+      });
+    });
+
+    describe(`progress`, () => {
+      test(`should be disabled when progress is shown`, () => {
+        expect(spectator.query('button')).not.toBeDisabled();
+        spectator.setInput('showProgress', true);
+        expect(spectator.query('button')).toBeDisabled();
+        expect(spectator.query('.c-button__spinner')).toExist();
+      });
+    });
+
+    describe(`button click`, () => {
+      test(`should emit the click event`, () => {
+        let output = void 0;
+        spectator.output('clicked').subscribe(result => (output = result));
+
+        expect(output).toBeUndefined();
+        spectator.click(spectator.query('button'));
+        expect(output).toBeTruthy();
+      });
+
+      test(`should not emit when interceptClick is true and store the original event`, () => {
+        spectator.setInput('interceptClick', true);
+        expect(spectator.component.originalClickEvent).not.toExist();
+        let output = void 0;
+        spectator.output('clicked').subscribe(result => (output = result));
+
+        spectator.click(spectator.query('button'));
+        expect(output).toBeUndefined();
+        expect(spectator.component.originalClickEvent).toExist();
+      });
+    });
+
+    describe(`ID`, function() {
+      test(`should default to the UID`, () => {
+        expect(spectator.query('button').getAttribute('id')).toEqual(expect.stringContaining('ts-button-'));
+      });
+
+      test(`should support a custom ID and fall back to UID if no value is passed`, () => {
+        spectator.setInput('id', 'foo');
+        expect(spectator.query('button')).toHaveAttribute('id', 'foo');
+        spectator.setInput('id', undefined);
+        expect(spectator.query('button').getAttribute('id')).toEqual(expect.stringContaining('ts-button-'));
+      });
+    });
+
+    describe(`collapsible`, () => {
+      test(`should set a collapse delay if none exists`, () => {
+        expect(spectator.component.collapseDelay).toBeUndefined();
+        spectator.setInput('format', 'collapsible');
+        expect(spectator.component.collapseDelay).toEqual(4000);
+      });
+
+      test(`should not set a collapse delay if one is set by consumer`, () => {
+        spectator.setInput('collapseDelay', 250);
+        expect(spectator.component.collapseDelay).toEqual(250);
+        spectator.setInput('format', 'collapsible');
+        expect(spectator.component.collapseDelay).toEqual(250);
+      });
+
+      test(`should remove collapse delay if format is changed from collapsible`, () => {
+        spectator.setInput('collapseDelay', 250);
+        expect(spectator.component.collapseDelay).toEqual(250);
+        spectator.setInput('format', 'filled');
+        expect(spectator.component.collapseDelay).toBeUndefined();
+      });
+
+      test(`should collapse button after delay`, fakeAsync(() => {
+        expect.assertions(4);
+        expect(spectator.query('button')).not.toHaveClass('c-button--collapsed');
+        expect(spectator.query('button')).not.toHaveClass('c-button--collapsible');
+        spectator.setInput('format', 'collapsible');
+        spectator.tick(2000);
+        expect(spectator.query('button')).not.toHaveClass('c-button--collapsed');
+        spectator.tick(10000);
+        expect(spectator.query('button')).toHaveClass('c-button--collapsed');
+      }));
+
+      test(`should clear the timeout if the consumer sets the collapsed state`, fakeAsync(() => {
+        spectator.setInput('format', 'collapsible');
+        spectator.tick(1000);
+        expect(spectator.query('button')).not.toHaveClass('c-button--collapsed');
+        spectator.setInput('collapsed', true);
+        expect(spectator.component.collapseSubscription$).toBeUndefined();
+        expect(spectator.component.isCollapsed).toBeTruthy();
+      }));
     });
   });
 
-  describe(`collapseWithDelay()`, () => {
-    beforeEach(() => {
-      buttonComponent.format = 'collapsible';
-      buttonComponent['windowService'].nativeWindow.setTimeout = window.setTimeout;
+  describe(`content`, () => {
+    let spectatorHost: SpectatorHost<TsButtonComponent>;
+    const createHost = createHostFactory({
+      component: TsButtonComponent,
+      imports: [TsButtonModule],
+      declareComponent: false,
     });
 
-    test(`should set isCollapsed and trigger change detection after the delay`, () => {
-      jest.useFakeTimers();
-      const DELAY = 100;
-      buttonComponent['collapseWithDelay'](DELAY);
-      jest.advanceTimersByTime(2000);
-      fixture.detectChanges();
-
-      expect(buttonComponent.isCollapsed).toEqual(true);
-      jest.runAllTimers();
-      expect(button.classList).toContain('c-button--collapsible');
-    });
-  });
-
-  describe(`ID`, function() {
-    test(`should support a custom ID`, () => {
-      expect(button.getAttribute('id')).toEqual('foo');
+    test(`should allow content to be set through ng-content`, () => {
+      spectatorHost = createHost(`<ts-button>Foo</ts-button>`);
+      expect(spectatorHost.query('.c-button__content-ng-content')).toHaveText('Foo');
     });
 
-    test(`should fall back to the UID if no ID is passed in`, () => {
-      component.myId = undefined as any;
-      fixture.detectChanges();
-      expect(button.getAttribute('id')).toContain('ts-button-');
+    test(`should allow content to be set through the textContent input`, () => {
+      spectatorHost = createHost(`<ts-button textContent="Bar"></ts-button>`);
+      expect(spectatorHost.query('.c-button__content-input')).toHaveText('Bar');
     });
   });
 });

--- a/stories/ui-button/button.stories.ts
+++ b/stories/ui-button/button.stories.ts
@@ -47,14 +47,15 @@ export default {
   ],
 };
 
-export const themes = () => ({
+export const themesAndSize = () => ({
   template: `
     <style>
     ts-button {
       margin-right: 1em
     }
     </style>
-    <div>
+    <div style="margin-bottom: 2rem;">
+      <h3>Standard</h3>
       <ts-button
         [icon]="withIcon ? icon : undefined"
         theme="default"
@@ -70,8 +71,14 @@ export const themes = () => ({
         theme="warning"
         (clicked)="onClick($event)"
       >My Button</ts-button>
+      <ts-button
+        [icon]="withIcon ? icon : undefined"
+        theme="alternate-primary"
+        (clicked)="onClick($event)"
+      >My Button</ts-button>
     </div>
-    <div>
+    <div style="margin-bottom: 2rem;">
+      <h3>Standard Disabled</h3>
       <ts-button
         [icon]="withIcon ? icon : undefined"
         theme="default"
@@ -90,7 +97,59 @@ export const themes = () => ({
         [isDisabled]="true"
         (clicked)="onClick($event)"
       >My Button</ts-button>
+      <ts-button
+        [icon]="withIcon ? icon : undefined"
+        theme="alternate-primary"
+        [isDisabled]="true"
+        (clicked)="onClick($event)"
+      >My Button</ts-button>
     </div>
+    <div style="margin-bottom: 2rem;">
+      <h3>Small</h3>
+      <ts-button
+        [icon]="withIcon ? icon : undefined"
+        theme="default"
+        [isSmall]="true"
+        (clicked)="onClick($event)"
+      >My Button</ts-button>
+      <ts-button
+        [icon]="withIcon ? icon : undefined"
+        theme="secondary"
+        [isSmall]="true"
+        (clicked)="onClick($event)"
+      >My Button</ts-button>
+      <ts-button
+        [icon]="withIcon ? icon : undefined"
+        theme="warning"
+        [isSmall]="true"
+        (clicked)="onClick($event)"
+      >My Button</ts-button>
+      <ts-button
+        [icon]="withIcon ? icon : undefined"
+        theme="alternate-primary"
+        [isSmall]="true"
+        (clicked)="onClick($event)"
+      >My Button</ts-button>
+    </div>
+  `,
+  props: {
+    withIcon: boolean('With Icon', true),
+    icon: faHome,
+    icon2: faPlus,
+    onClick: action('log'),
+  },
+});
+themesAndSize.parameters = {
+  docs: { iframeHeight: 340 },
+};
+
+export const collapsible = () => ({
+  template: `
+    <style>
+    ts-button {
+      margin-right: 1em
+    }
+    </style>
     <div style="text-align: end">
       <ts-button
         [icon]="icon2"
@@ -111,6 +170,7 @@ export const themes = () => ({
         [icon]="icon2"
         theme="secondary"
         format="collapsible"
+        [collapseDelay]="4100"
         (clicked)="onClick($event)"
       >My Button</ts-button>
       <ts-button
@@ -126,6 +186,7 @@ export const themes = () => ({
         [icon]="icon2"
         theme="warning"
         format="collapsible"
+        [collapseDelay]="4200"
         (clicked)="onClick($event)"
       >My Button</ts-button>
       <ts-button
@@ -138,12 +199,13 @@ export const themes = () => ({
     </div>
   `,
   props: {
-    withIcon: boolean('With Icon', true),
     icon: faHome,
     icon2: faPlus,
     onClick: action('log'),
   },
 });
-themes.parameters = {
-  docs: { iframeHeight: 260 },
+collapsible.parameters = {
+  actions: { disabled: true },
+  knobs: { disabled: true },
+  docs: { iframeHeight: 180 },
 };

--- a/tools/ci/run-chromatic-with-changed-projects.sh
+++ b/tools/ci/run-chromatic-with-changed-projects.sh
@@ -27,9 +27,11 @@ if [[ -n "$LERNA_OUTPUT" ]]; then
 
   for project in "${PROJECT_ARRAY[@]}"
   do
-    files=$(find $project -name "*.stories.[tj]s" 2> /dev/null | wc -l)
+    shortName="$(basename "${project}")"
+    shortProjectName="stories/ui-${shortName}"
+    files=$(find "$shortProjectName" -name "*.stories.[tj]s" 2> /dev/null | wc -l)
     if [[ $files != "0" ]]; then
-      links+="'$project/**/*.stories.[tj]s',"
+      links+="'$GITHUB_WORKSPACE/$shortProjectName/**/*.stories.[tj]s',"
     fi
   done
 


### PR DESCRIPTION
- support `textContent` input
- support new `alternate-primary` theme - closes #378 
- support new `isSmall` param - closes #441 
- rewrite unit tests as integration
- fix storybook:all project to include new stories dir
- refactored collapse functionality to no longer depend on setTimeout
- slightly improve collapse/expand animations