### PR TITLE
feat(Button): remove FontAwesome, remove collapsible format

### DIFF
--- a/libs/ui/button/README.md
+++ b/libs/ui/button/README.md
@@ -8,14 +8,11 @@
 ## Table of Contents
 
 - [Installation](#installation)
-  - [Packages that need to be included](#packages-that-need-to-be-included)
-  - [Modules that need to be in NgModule](#modules-that-need-to-be-in-ngmodule)
   - [CSS imports](#css-imports)
   - [CSS resources](#css-resources)
 - [Usage](#usage)
   - [Text content](#text-content)
   - [Theme](#theme)
-  - [Format](#format)
   - [Size](#size)
   - [Button type](#button-type)
   - [Action name](#action-name)
@@ -25,27 +22,11 @@
 
 ## Installation
 
-### Packages that need to be included
-
-- `@angular/cdk`
-- `@angular/material`
-- `@terminus/fe-utilities`
-- `@terminus/design-tokens`
-- `@terminus/ui-button`
-- `@terminus/ui-icon`
-- `@terminus/ui-utilities`
-- `@terminus/ui-styles`
-- `date-fns`
-
 Use the `ng add` command to quickly install all the needed dependencies:
 
 ```bash
 ng add @terminus/ui-button
 ```
-
-### Modules that need to be in NgModule
-
-- `TsButtonModule`
 
 ### CSS imports
 
@@ -62,6 +43,9 @@ Load the needed font families by adding this link to the `<head>` of your applic
 
 ```css
 <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
+<!-- Don't forget to update the integrity SHA -->
+<link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.15.1/css/solid.css" integrity="SHA-HERE" crossorigin="anonymous">
+<link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.15.1/css/fontawesome.css" integrity="SHA-HERE" crossorigin="anonymous">
 ```
 
 ## Usage
@@ -88,16 +72,6 @@ Set any available theme type:
 ```
 
 See `TsButtonThemeTypes` for all available themes.
-
-### Format
-
-Set any available format:
-
-```html
-<ts-button format="collapsible">Click Me!</ts-button>
-```
-
-See `TsButtonFormatTypes` for all available button formats.
 
 ### Size
 
@@ -129,7 +103,7 @@ See `TsButtonActionTypes` for all available action names.
 
 ### Show progress
 
-When 'showing progress', the button will be disabled and a spinner will be shown:
+When 'showing progress', the button will be disabled, and a spinner will be shown:
 
 ```html
 <ts-button [showProgress]="true">Click Me!</ts-button>

--- a/libs/ui/button/ng-package.json
+++ b/libs/ui/button/ng-package.json
@@ -2,11 +2,6 @@
   "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../../dist/libs/ui/button",
   "lib": {
-    "entryFile": "src/index.ts",
-    "umdModuleIds": {
-      "@terminus/fe-utilities": "terminus.fe-utilities",
-      "@terminus/ui-icon": "terminus.ui-icon",
-      "@terminus/ui-utilities": "terminus.ui-utilities"
-    }
+    "entryFile": "src/index.ts"
   }
 }

--- a/libs/ui/button/package.json
+++ b/libs/ui/button/package.json
@@ -17,24 +17,14 @@
     "tag": "next",
     "directory": "../../../dist/libs/ui/button"
   },
+  "dependencies": {
+    "tslib": "^1.10.0"
+  },
   "peerDependencies": {
     "@angular/common": "^9.1.0",
     "@angular/core": "^9.1.0",
-    "@angular/forms": "^9.1.0",
-    "@angular/material": "^9.2.4",
-    "@angular/platform-browser": "^9.1.0",
-    "@fortawesome/angular-fontawesome": "^0.6.0",
-    "@fortawesome/fontawesome-svg-core": "^1.2.30",
-    "@fortawesome/pro-solid-svg-icons": "^5.14.0",
     "@terminus/design-tokens": "^3.1.0",
-    "@terminus/fe-utilities": "^1.0.0",
-    "@terminus/ui-icon": "^2.1.4",
-    "@terminus/ui-spacing": "^1.1.3",
-    "@terminus/ui-styles": "^1.1.0",
-    "@terminus/ui-utilities": "^1.0.9",
-    "date-fns": "^2.16.1",
-    "rxjs": "^6.5.0",
-    "tslib": "^1.10.0"
+    "@terminus/ui-styles": "^1.1.0"
   },
   "scripts": {
     "build": "../../../node_modules/.bin/tsc -p tsconfig.schematics.json",

--- a/libs/ui/button/schematics/ng-add/index.ts
+++ b/libs/ui/button/schematics/ng-add/index.ts
@@ -11,20 +11,11 @@ import {
 
 export const ngAdd = () => (tree: Tree, context: SchematicContext): Tree => {
   [
-    '@angular/cdk: ^9.2.4',
     '@angular/common: ^9.1.0',
     '@angular/core: ^9.1.0',
-    '@angular/flex-layout: ~9.0.0-beta.29',
-    '@angular/forms: ^9.1.0',
-    '@angular/material: ^9.2.4',
-    '@angular/platform-browser: ^9.1.0',
     '@terminus/design-tokens: ^3.1.0',
-    '@terminus/fe-utilities: ^1.0.0',
-    '@terminus/ui-utilities: ^1.0.9',
-    '@terminus/ui-button: ^2.0.7',
-    '@terminus/ui-icon: ^2.0.5',
+    '@terminus/ui-button: ^3.0.0',
     '@terminus/ui-styles: ^1.1.0',
-    'date-fns: ^2.14.0',
   ].map(p => {
     const individualPackage = p.split(':');
     const nodeDependency: NodeDependency = {

--- a/libs/ui/button/src/lib/button/button.component.html
+++ b/libs/ui/button/src/lib/button/button.component.html
@@ -1,7 +1,6 @@
 <button
-  class="c-button c-button--{{ theme }} c-button--{{ format }}"
+  class="c-button c-button--{{ theme }}"
   [ngClass]="{
-    'c-button--collapsed': isCollapsed,
     'c-button--progress': showProgress && !isDisabled,
     'c-button--small': isSmall
   }"
@@ -13,22 +12,18 @@
   (click)="clickedButton($event)"
   #button
 >
-  <ts-icon
-    *ngIf="icon"
-    class="c-button__icon"
-    [icon]="icon"
-  ></ts-icon>
-
   <span class="c-button__content">
     <span class="c-button__content-ng-content"><ng-content></ng-content></span>
     <span class="c-button__content-input">{{ textContent }}</span>
   </span>
 
-  <mat-progress-spinner
-    *ngIf="showProgress && !isDisabled"
+  <span
     class="c-button__spinner"
+    *ngIf="showProgress && !isDisabled"
     [ngClass]="{'c-button__spinner--active': showProgress && !isDisabled}"
-    diameter="21"
-    mode="indeterminate"
-  ></mat-progress-spinner>
+  >
+    <svg width="100%" height="100%" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
+      <circle fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle>
+    </svg>
+  </span>
 </button>

--- a/libs/ui/button/src/lib/button/button.component.scss
+++ b/libs/ui/button/src/lib/button/button.component.scss
@@ -80,32 +80,47 @@
   --tsb-collapsible-first-icon-adjustment: -.15em;
   // NOTE: This is to better align with inputs that have extra space above and below
   --tsb-margin: 4px 0;
-  --tsb-padding: 0 var(--ts-space-inset-400);
+  --tsb-padding-base: var(--ts-space-inset-400);
+  --tsb-padding: 0 var(--tsb-padding-base);
   --tsb-padding-collapsed: 0 6px;
   --tsb-borderRadius: var(--ts-border-radius-base);
   --tsb-borderRadius-collapsible: 2em;
-  --tsb-padding-right-progress: 42px;
+  --tsb-padding-right-progress: 44px;
   --tsb-icon-vertical-adjustment: -.15em;
   --tsb-icon-horizontal-adjustment: .2em;
   --tsb-icon-padding: 0 .2em;
   --tsb-shadow-focus: 0 0 2px 2px var(--tsb-boxShadow-color);
   --tsb-content-maxWidth: 400px;
   --tsb-spinner-color: var(--ts-color-utility-500);
-
-  // NOTE: All transition durations are based off of the content transition.
   --tsb-animationEasing: var(--ts-animation-easing-ease);
-  --tsb-content-transitionDuration: var(--ts-animation-time-duration-500);
-  --tsb-icon-transitionDuration-collapse: calc(var(--tsb-content-transitionDuration) - 100ms);
-  --tsb-icon-transitionDuration-expand: calc(var(--tsb-icon-transitionDuration-collapse) - 100ms);
-  --tsb-label-transitionDuration: calc(var(--tsb-icon-transitionDuration-expand) - 100ms);
-  --tsb-maxWidth-transition: max-width var(--tsb-content-transitionDuration) var(--tsb-animationEasing);
-  --tsb-maxWidth-hover-transition: max-width calc(var(--tsb-content-transitionDuration) + 100ms) ease-in-out;
-  --tsb-padding-expand-transition: padding calc(var(--tsb-content-transitionDuration) - 300ms) var(--ts-animation-easing-ease) var(--ts-animation-time-delay-200);
-  --tsb-icon-expand-transition: margin-right calc(var(--tsb-content-transitionDuration) - 400ms) var(--ts-animation-easing-easeOut) var(--ts-animation-time-delay-100);
-  --tsb-icon-transition: transform var(--tsb-icon-transitionDuration-expand) var(--tsb-animationEasing);
-  --tsb-spinner-transition: opacity var(--tsb-label-transitionDuration) var(--tsb-animationEasing);
-  --tsb-icon-collapsed-transitionDelay: 150ms;
-  --tsb-icon-collapsed-hover-transitionDelay: 0ms;
+  --tsb-content-transitionDuration: var(--ts-animation-time-duration-400);
+  --tsb-spinner-transition: opacity calc(var(--tsb-content-transitionDuration) - 200ms) var(--tsb-animationEasing);
+  --tsb-spinner-xy: 21px;
+}
+
+// Spinner animations and values
+$offset: 187;
+$duration: 1.4s;
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(270deg);
+  }
+}
+@keyframes dash {
+  0% {
+    stroke-dashoffset: $offset;
+  }
+  50% {
+    stroke-dashoffset: $offset / 4;
+    transform: rotate(135deg);
+  }
+  100% {
+    stroke-dashoffset: $offset;
+    transform: rotate(450deg);
+  }
 }
 
 .ts-button {
@@ -178,6 +193,7 @@
 
     // Target the prefix icon
     &__icon {
+      display: inline-block;
       margin-right: var(--tsb-icon-horizontal-adjustment);
     }
 
@@ -192,30 +208,32 @@
       }
     }
 
-    // Target any icon inside a button
-    // Adjust icon vertical layout
-    .c-icon {
-      // Fix small vertical alignment issue between icon & text
-      margin-top: var(--tsb-icon-vertical-adjustment);
-      transition: var(--tsb-icon-transition);
-      vertical-align: middle;
-    }
-
-    // Overwrite the Material spinner to fit our layout
     .c-button__spinner {
-      display: inline-block;
+      display: block;
+      height: var(--tsb-spinner-xy);
       opacity: 0;
       position: absolute;
-      right: 12px;
-      top: 6px;
+      right: var(--tsb-padding-base);
+      top: 50%;
+      transform: translateY(calc(-50% - 2px));
       transition: var(--tsb-spinner-transition);
+      width: var(--tsb-spinner-xy);
 
       &--active {
         opacity: 1;
       }
 
+      svg {
+        animation: rotation $duration linear infinite;
+        transform-origin: center;
+      }
+
       circle {
+        animation: dash $duration ease-in-out infinite;
         stroke: var(--tsb-spinner-color);
+        stroke-dasharray: $offset;
+        stroke-dashoffset: 0;
+        transform-origin: center;
       }
     }
 
@@ -228,84 +246,9 @@
       line-height: 14px;
       padding: 4px 8px;
 
-      .ts-icon {
+      .fa,
+      .fas {
         transform: scale(.84);
-      }
-    }
-
-    // COLLAPSIBLE
-    &--collapsible {
-      border-radius: var(--tsb-borderRadius-collapsible);
-
-      // When collapsible AND disabled
-      &.c-button--collapsed,
-      &[disabled] {
-        &:not(:hover) {
-          &:not(:focus) {
-            padding: var(--tsb-padding-collapsed);
-            // Custom transition with delay needed to remove 'jump' during collapse
-            transition: var(--tsb-padding-expand-transition);
-
-            .ts-icon {
-              margin-right: 0;
-              // Custom transition with delay needed to remove 'jump' during collapse
-              transition: var(--tsb-icon-expand-transition);
-            }
-
-            .c-icon {
-              position: relative;
-              transform: rotate(var(--tsb-rotation));
-              transition-duration: var(--tsb-icon-transitionDuration-collapse);
-            }
-
-            // collapse the text content
-            .c-button__content {
-              --tsb-content-maxWidth: 0;
-            }
-          }
-        }
-      }
-
-      // Fix left alignment when button is expanded and an icon is the first item
-      &.c-button--collapsed {
-        &:hover,
-        &:focus {
-          .c-button__content {
-            transition: var(--tsb-maxWidth-hover-transition);
-          }
-
-          .c-icon {
-            margin-left: var(--tsb-collapsible-first-icon-adjustment);
-            transition-delay: var(--tsb-icon-collapsed-hover-transitionDelay);
-          }
-        }
-
-        .c-icon {
-          transition-delay: var(--tsb-icon-collapsed-transitionDelay);
-        }
-      }
-
-      // Padding addition for FontAwesome switch
-      .c-icon {
-        padding: var(--tsb-icon-padding);
-      }
-
-      .c-button__content {
-        display: inline-block;
-        max-width: var(--tsb-content-maxWidth);
-        overflow: hidden;
-        transition: var(--tsb-maxWidth-transition);
-        vertical-align: bottom;
-        white-space: nowrap;
-
-        .ts-icon {
-          margin-left: var(--tsb-icon-negative-padding-adjustment);
-          margin-right: var(--tsb-icon-negative-padding-adjustment);
-        }
-      }
-
-      .mat-ripple {
-        border-radius: var(--tsb-borderRadius-collapsible);
       }
     }
   }

--- a/libs/ui/button/src/lib/button/button.component.ts
+++ b/libs/ui/button/src/lib/button/button.component.ts
@@ -1,6 +1,5 @@
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
@@ -9,14 +8,6 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import type { OnDestroy } from '@angular/core';
-import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import {
-  Subscription,
-  timer,
-} from 'rxjs';
-
-import { untilComponentDestroyed } from '@terminus/fe-utilities';
 
 // Unique ID for each instance
 let nextUniqueId = 0;
@@ -52,22 +43,6 @@ export const tsButtonFunctionTypes = [
 ];
 
 /**
- * Define the allowed {@link TsButtonComponent} format types
- */
-export type TsButtonFormatTypes
-  = 'filled'
-  | 'collapsible'
-;
-
-/**
- * @internal
- */
-export const tsButtonFormatTypesArray: ReadonlyArray<TsButtonFormatTypes> = [
-  'filled',
-  'collapsible',
-];
-
-/**
  * Supported themes for buttons
  */
 export type TsButtonThemeTypes
@@ -88,24 +63,12 @@ export const tsButtonThemes: ReadonlyArray<TsButtonThemeTypes> = [
 ];
 
 /**
- * The default collapse delay in milliseconds
- *
- * @internal
- */
-const DEFAULT_COLLAPSE_DELAY_MS = 4000;
-
-
-/**
  * A presentational component to render a button
  *
  * @example
  * <ts-button
  *              actionName="Submit"
  *              buttonType="search"
- *              [collapsed]="false"
- *              collapseDelay="500"
- *              format="filled"
- *              [icon]="myIconReference"
  *              [isDisabled]="false"
  *              [isSmall]="true"
  *              [showProgress]="true"
@@ -126,17 +89,7 @@ const DEFAULT_COLLAPSE_DELAY_MS = 4000;
   encapsulation: ViewEncapsulation.None,
   exportAs: 'tsButton',
 })
-export class TsButtonComponent implements OnDestroy {
-  /**
-   * Store a reference to the collapsible subscription
-   */
-  public collapseSubscription$: Subscription | undefined;
-
-  /**
-   * The flag that defines if the button is collapsed or expanded
-   */
-  public isCollapsed = false;
-
+export class TsButtonComponent {
   /**
    * A flag to determine if click events should be intercepted.
    *
@@ -182,53 +135,6 @@ export class TsButtonComponent implements OnDestroy {
    */
   @Input()
   public buttonType: TsButtonFunctionTypes = 'button';
-
-  /**
-   * Define the delay before the rounded button automatically collapses
-   */
-  @Input()
-  public collapseDelay: number | undefined;
-
-  /**
-   * Define the collapsed value and trigger the delay if needed
-   *
-   * @param value
-   */
-  @Input()
-  public set collapsed(value: boolean) {
-    this.isCollapsed = value;
-    this.cleanUpCollapseSubscription();
-  }
-
-  /**
-   * Define the button format. {@link TsButtonFormatTypes}
-   *
-   * @param value
-   */
-  @Input()
-  public set format(value: TsButtonFormatTypes) {
-    this._format = value ? value : 'filled';
-
-    // istanbul ignore else
-    if (this._format === 'collapsible') {
-      this.setUpCollapse();
-    } else if (this.collapseDelay) {
-      // If the format is NOT collapsible clean up any unneeded settings
-      this.collapseDelay = undefined;
-      // istanbul ignore else
-      this.cleanUpCollapseSubscription();
-    }
-  }
-  public get format(): TsButtonFormatTypes {
-    return this._format;
-  }
-  private _format: TsButtonFormatTypes = 'filled';
-
-  /**
-   * Define an icon to include
-   */
-  @Input()
-  public icon: IconProp | undefined;
 
   /**
    * Define if the button is disabled
@@ -296,17 +202,7 @@ export class TsButtonComponent implements OnDestroy {
   @Output()
   public readonly clicked = new EventEmitter<MouseEvent>();
 
-  constructor(
-    public elementRef: ElementRef,
-    private changeDetectorRef: ChangeDetectorRef,
-  ) {}
-
-  /**
-   * Clear any existing timeout
-   */
-  public ngOnDestroy(): void {
-    this.cleanUpCollapseSubscription();
-  }
+  constructor(public elementRef: ElementRef) {}
 
   /**
    * Handle button clicks
@@ -322,35 +218,6 @@ export class TsButtonComponent implements OnDestroy {
     } else {
       // Allow the click to propagate
       this.clicked.emit(event);
-    }
-  }
-
-  /**
-   * Set up the timer to collapse the button after a delay
-   */
-  private setUpCollapse(): void {
-    // istanbul ignore else
-    if (!this.collapseDelay) {
-      this.collapseDelay = DEFAULT_COLLAPSE_DELAY_MS;
-    }
-    this.cleanUpCollapseSubscription();
-
-    this.collapseSubscription$ = timer(this.collapseDelay)
-      .pipe(untilComponentDestroyed(this))
-      .subscribe(() => {
-        this.isCollapsed = true;
-        this.changeDetectorRef.detectChanges();
-      });
-  }
-
-  /**
-   * Clean up the collapse subscription
-   */
-  private cleanUpCollapseSubscription(): void {
-    // istanbul ignore else
-    if (this.collapseSubscription$) {
-      this.collapseSubscription$.unsubscribe();
-      this.collapseSubscription$ = undefined;
     }
   }
 }

--- a/libs/ui/button/src/lib/ui-button.module.ts
+++ b/libs/ui/button/src/lib/ui-button.module.ts
@@ -1,21 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-
-import { TsWindowService } from '@terminus/fe-utilities';
-import { TsIconModule } from '@terminus/ui-icon';
 
 import { TsButtonComponent } from './button/button.component';
 
 export * from './button/button.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    MatProgressSpinnerModule,
-    TsIconModule,
-  ],
-  providers: [TsWindowService],
+  imports: [CommonModule],
   exports: [TsButtonComponent],
   declarations: [TsButtonComponent],
 })

--- a/specs/ui-button/button.component.spec.ts
+++ b/specs/ui-button/button.component.spec.ts
@@ -1,4 +1,3 @@
-import { fakeAsync } from '@angular/core/testing';
 import { Spectator } from '@ngneat/spectator';
 import {
   createComponentFactory,
@@ -60,21 +59,6 @@ describe(`TsButtonComponent`, () => {
       expect(spectator.query('button')).toBeDisabled();
     });
 
-    describe(`format`, () => {
-      test(`should reflect the format as a class`, () => {
-        expect(spectator.query('button')).toHaveClass('c-button--filled');
-        spectator.setInput('format', 'collapsible');
-        expect(spectator.query('button')).toHaveClass('c-button--collapsible');
-      });
-
-      test(`should default to 'filled' format if nothing is passed in`, () => {
-        spectator.setInput('format', 'collapsible');
-        expect(spectator.component.format).toEqual('collapsible');
-        spectator.setInput('format', undefined);
-        expect(spectator.component.format).toEqual('filled');
-      });
-    });
-
     describe(`progress`, () => {
       test(`should be disabled when progress is shown`, () => {
         expect(spectator.query('button')).not.toBeDisabled();
@@ -117,48 +101,6 @@ describe(`TsButtonComponent`, () => {
         spectator.setInput('id', undefined);
         expect(spectator.query('button').getAttribute('id')).toEqual(expect.stringContaining('ts-button-'));
       });
-    });
-
-    describe(`collapsible`, () => {
-      test(`should set a collapse delay if none exists`, () => {
-        expect(spectator.component.collapseDelay).toBeUndefined();
-        spectator.setInput('format', 'collapsible');
-        expect(spectator.component.collapseDelay).toEqual(4000);
-      });
-
-      test(`should not set a collapse delay if one is set by consumer`, () => {
-        spectator.setInput('collapseDelay', 250);
-        expect(spectator.component.collapseDelay).toEqual(250);
-        spectator.setInput('format', 'collapsible');
-        expect(spectator.component.collapseDelay).toEqual(250);
-      });
-
-      test(`should remove collapse delay if format is changed from collapsible`, () => {
-        spectator.setInput('collapseDelay', 250);
-        expect(spectator.component.collapseDelay).toEqual(250);
-        spectator.setInput('format', 'filled');
-        expect(spectator.component.collapseDelay).toBeUndefined();
-      });
-
-      test(`should collapse button after delay`, fakeAsync(() => {
-        expect.assertions(4);
-        expect(spectator.query('button')).not.toHaveClass('c-button--collapsed');
-        expect(spectator.query('button')).not.toHaveClass('c-button--collapsible');
-        spectator.setInput('format', 'collapsible');
-        spectator.tick(2000);
-        expect(spectator.query('button')).not.toHaveClass('c-button--collapsed');
-        spectator.tick(10000);
-        expect(spectator.query('button')).toHaveClass('c-button--collapsed');
-      }));
-
-      test(`should clear the timeout if the consumer sets the collapsed state`, fakeAsync(() => {
-        spectator.setInput('format', 'collapsible');
-        spectator.tick(1000);
-        expect(spectator.query('button')).not.toHaveClass('c-button--collapsed');
-        spectator.setInput('collapsed', true);
-        expect(spectator.component.collapseSubscription$).toBeUndefined();
-        expect(spectator.component.isCollapsed).toBeTruthy();
-      }));
     });
   });
 

--- a/stories/ui-button/.storybook/preview-head.html
+++ b/stories/ui-button/.storybook/preview-head.html
@@ -2,6 +2,8 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@terminus/ui-styles/terminus-ui.min.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@terminus/design-tokens/css/design-tokens.min.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@terminus/design-tokens/css/library-design-tokens.min.css">
+<link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.15.1/css/solid.css" integrity="sha384-LRz1HmzqffP7wO7piC0QSObi89cOdpFP7qMIx/UZ+qK2TdoDBdl+LidxFVnYu23p" crossorigin="anonymous">
+<link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.15.1/css/fontawesome.css" integrity="sha384-RFOcGND+1HYm6OyEAF5WKkoZnwv/cXQpCX6KduKC1vAKAoohkNYWNPhkx4fsH9Fn" crossorigin="anonymous">
 
 <style type="text/css">
   html {

--- a/stories/ui-button/button.stories.ts
+++ b/stories/ui-button/button.stories.ts
@@ -1,8 +1,3 @@
-import { APP_INITIALIZER } from '@angular/core';
-import {
-  FaIconLibrary,
-  FontAwesomeModule,
-} from '@fortawesome/angular-fontawesome';
 import { faPlus } from '@fortawesome/pro-solid-svg-icons';
 import { faHome } from '@fortawesome/pro-solid-svg-icons/faHome';
 import { action } from '@storybook/addon-actions';
@@ -16,8 +11,6 @@ import {
   TsButtonModule,
   TsButtonComponent,
 } from '@terminus/ui-button';
-import { TsIconModule } from '@terminus/ui-icon';
-import { TsSpacingModule } from '@terminus/ui-spacing';
 
 export default {
   title: 'Components/Actions/Button',
@@ -25,24 +18,7 @@ export default {
   decorators: [
     withKnobs,
     moduleMetadata({
-      imports: [
-        FontAwesomeModule,
-        TsButtonModule,
-        TsIconModule,
-        TsSpacingModule,
-      ],
-      providers: [
-        {
-          provide: APP_INITIALIZER,
-          useFactory: (iconLibrary: FaIconLibrary) => async() => {
-            // Add the necessary icons inside the initializer body.
-            iconLibrary.addIcons(faHome);
-          },
-          // When using a factory provider you need to explicitly specify its dependencies.
-          deps: [FaIconLibrary],
-          multi: true,
-        },
-      ],
+      imports: [TsButtonModule],
     }),
   ],
 };
@@ -57,79 +33,111 @@ export const themesAndSize = () => ({
     <div style="margin-bottom: 2rem;">
       <h3>Standard</h3>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="default"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="secondary"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="warning"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="alternate-primary"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
+      <ts-button
+        theme="alternate-primary"
+        [showProgress]="true"
+        (clicked)="onClick($event)"
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
     </div>
     <div style="margin-bottom: 2rem;">
       <h3>Standard Disabled</h3>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="default"
         [isDisabled]="true"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="secondary"
         [isDisabled]="true"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="warning"
         [isDisabled]="true"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="alternate-primary"
         [isDisabled]="true"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
     </div>
     <div style="margin-bottom: 2rem;">
       <h3>Small</h3>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="default"
         [isSmall]="true"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="secondary"
         [isSmall]="true"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="warning"
         [isSmall]="true"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
       <ts-button
-        [icon]="withIcon ? icon : undefined"
         theme="alternate-primary"
         [isSmall]="true"
         (clicked)="onClick($event)"
-      >My Button</ts-button>
+      >
+        <span *ngIf="withIcon" class="fas fa-home"></span>
+        My Button
+      </ts-button>
     </div>
   `,
   props: {
@@ -143,69 +151,3 @@ themesAndSize.parameters = {
   docs: { iframeHeight: 340 },
 };
 
-export const collapsible = () => ({
-  template: `
-    <style>
-    ts-button {
-      margin-right: 1em
-    }
-    </style>
-    <div style="text-align: end">
-      <ts-button
-        [icon]="icon2"
-        theme="default"
-        format="collapsible"
-        (clicked)="onClick($event)"
-      >My Button</ts-button>
-      <ts-button
-        [icon]="icon2"
-        theme="default"
-        format="collapsible"
-        [isDisabled]="true"
-        (clicked)="onClick($event)"
-      >My Button</ts-button>
-    </div>
-    <div style="text-align: end">
-      <ts-button
-        [icon]="icon2"
-        theme="secondary"
-        format="collapsible"
-        [collapseDelay]="4100"
-        (clicked)="onClick($event)"
-      >My Button</ts-button>
-      <ts-button
-        [icon]="icon2"
-        theme="secondary"
-        format="collapsible"
-        [isDisabled]="true"
-        (clicked)="onClick($event)"
-      >My Button</ts-button>
-    </div>
-    <div style="text-align: end">
-      <ts-button
-        [icon]="icon2"
-        theme="warning"
-        format="collapsible"
-        [collapseDelay]="4200"
-        (clicked)="onClick($event)"
-      >My Button</ts-button>
-      <ts-button
-        [icon]="icon2"
-        theme="warning"
-        format="collapsible"
-        [isDisabled]="true"
-        (clicked)="onClick($event)"
-      >My Button</ts-button>
-    </div>
-  `,
-  props: {
-    icon: faHome,
-    icon2: faPlus,
-    onClick: action('log'),
-  },
-});
-collapsible.parameters = {
-  actions: { disabled: true },
-  knobs: { disabled: true },
-  docs: { iframeHeight: 180 },
-};


### PR DESCRIPTION
- Remove dependency on FontAwesome closes #450
- Remove icon input
- Remove format input

---

This change accomplishes:

- Unblock all upstream packages that wish to remove the dependency on FontAwesome.
- Remove unneeded functionality to simplify ongoing maintenance.

BREAKING CHANGE:

• Format input no longer supported (collapsible buttons are no longer needed)
• Collapsed and collapseDelay inputs no longer supported
• Icon input no longer supported

### Migration Notes 3.0.0

1. Update any collapsible buttons by removing any of the 3 removed inputs:

```diff
<ts-button
- format="collapsible"
- collapseDelay="100"
- [collapsed]="true"
  (clicked)="myFunc($event)"
>Click me!</ts-button>
```

2. Update any buttons to use CDN icons instead of passing an icon reference in:

Import the needed styles:

```html
<!-- Don't forget to update the integrity SHA -->
<link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.15.1/css/solid.css" integrity="SHA-HERE" crossorigin="anonymous">
<link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.15.1/css/fontawesome.css" integrity="SHA-HERE" crossorigin="anonymous">
```

Pass your icon in as content:

```diff
<ts-button
- [icon]="myIcon"
  (clicked)="myFunc($event)"
>
+ <span class="fas fa-home"></span>
  Click me!
</ts-button>
```