### PR TITLE
fix(Checkbox): calc of left position is now correctly calculated.

### DIFF
--- a/libs/ui/checkbox/src/lib/checkbox/checkbox.component.scss
+++ b/libs/ui/checkbox/src/lib/checkbox/checkbox.component.scss
@@ -12,7 +12,7 @@
   // Custom margin added to match buttons so that both match the vertical offset of the input
   --ts-checkbox-outer-margin: 4px 0;
   --ts-checkbox-check-xy: 10px;
-  --ts-checkbox-box-left: 0;
+  --ts-checkbox-box-left: 0px;
   --ts-checkbox-svg-left: calc(var(--ts-checkbox-box-left) + 2px);
   --ts-checkbox-input-xy: 14px;
   --ts-checkbox-label-color: var(--ts-color-utility-600);


### PR DESCRIPTION
Browser ignores and do not calculate previous `calc(0 + 2px)`;

before
<img width="100" alt="Screenshot 2021-01-18 at 15 22 24" src="https://user-images.githubusercontent.com/11005870/104920842-1ad97e00-59a1-11eb-8a6f-bd9603fe1c0e.png">

after
<img width="105" alt="Screenshot 2021-01-18 at 15 22 55" src="https://user-images.githubusercontent.com/11005870/104920845-1b721480-59a1-11eb-9e5c-a72246908ed5.png">
