### PR TITLE
chore: correctly disable no zero unit rule

### DIFF
--- a/libs/stylelint-config-frontend/src/lib/rules.js
+++ b/libs/stylelint-config-frontend/src/lib/rules.js
@@ -61,7 +61,12 @@ module.exports = {
     'function-whitespace-after': 'always',
     'indentation': 2,
     'keyframe-declaration-no-important': true,
-    'length-zero-no-unit': true,
+    'length-zero-no-unit': [
+      true,
+      {
+        ignore: ['custom-properties'],
+      },
+    ],
     'linebreaks': 'unix',
     'max-empty-lines': 4,
     'media-feature-colon-space-after': 'always',
@@ -76,9 +81,7 @@ module.exports = {
     'no-eol-whitespace': [
       true,
       {
-        ignore: [
-          'empty-lines',
-        ],
+        ignore: ['empty-lines'],
       },
     ],
     'no-extra-semicolons': true,

--- a/libs/ui/copy/README.md
+++ b/libs/ui/copy/README.md
@@ -15,6 +15,8 @@ This component is used to contain very long strings that users may need to copy.
 - [Usage](#usage)
   - [Display format](#display-format)
   - [Initial selection](#initial-selection)
+  - [Quick copy](#quick-copy)
+  - [Events](#events)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -70,6 +72,22 @@ It should be extremely rare, but if needed, this functionality can be disabled.
 
 ```html
 <ts-copy [disableInitialSelection]="true">My text to copy!</ts-copy>
+```
+
+### Quick copy
+
+By default, a button will appear on hover that copies the content to the user's clipboard. This functionality can be disabled:
+
+```html
+<ts-copy [enableQuickCopy]="false">My text to copy!</ts-copy>
+```
+
+### Events
+
+On successful copy an event with the copied text is emitted:
+
+```html
+<ts-copy (copied)="didCopy($event)">My text to copy!</ts-copy>
 ```
 
 <!-- Links -->

--- a/libs/ui/copy/package.json
+++ b/libs/ui/copy/package.json
@@ -27,9 +27,9 @@
     "tslib": "^2.0.3"
   },
   "peerDependencies": {
+    "@angular/cdk": "^11.0.3",
     "@angular/common": "^11.0.4",
     "@angular/core": "^11.0.4",
-    "@angular/flex-layout": "~11.0.0-beta.33",
     "@angular/forms": "^11.0.4",
     "@angular/material": "^11.0.3",
     "@angular/platform-browser": "^11.0.4",

--- a/libs/ui/copy/schematics/ng-add/index.ts
+++ b/libs/ui/copy/schematics/ng-add/index.ts
@@ -11,9 +11,9 @@ import {
 
 export const ngAdd = () => (tree: Tree, context: SchematicContext): Tree => {
   [
+    '@angular/cdk: ^11.0.3',
     '@angular/common: ^11.0.4',
     '@angular/core: ^11.0.4',
-    '@angular/flex-layout: ~11.0.0-beta.33',
     '@angular/forms: ^11.0.4',
     '@angular/material: ^11.0.3',
     '@angular/platform-browser: ^11.0.4',

--- a/libs/ui/copy/src/lib/copy/copy.component.html
+++ b/libs/ui/copy/src/lib/copy/copy.component.html
@@ -1,15 +1,14 @@
 <div
   class="c-copy"
-  fxLayout="row"
   tabindex="0"
-  (click)="selectText(content, hasSelected, disableInitialSelection)"
   (blur)="resetSelection()"
+  (click)="selectText(content, hasSelected, disableInitialSelection)"
+  (focus)="selectText(content, hasSelected, disableInitialSelection)"
 >
     <div
       #content
       tabindex="1"
       class="c-copy__content"
-      fxFlex="auto"
     >
       <ts-tooltip [tooltipValue]="textContent">
         <ng-content></ng-content>
@@ -18,10 +17,7 @@
 
   <div class="c-copy__tooltip">
     <ts-tooltip tooltipValue="Copy to clipboard" *ngIf="enableQuickCopy">
-      <div
-        class="c-copy__icon"
-        (click)="copyToClipboard(textContent)"
-      >
+      <div class="c-copy__icon" [cdkCopyToClipboard]="textContent" (cdkCopyToClipboardCopied)="copied.emit(textContent)">
         <ng-container *ngTemplateOutlet="copyIcon"></ng-container>
       </div>
     </ts-tooltip>

--- a/libs/ui/copy/src/lib/copy/copy.component.scss
+++ b/libs/ui/copy/src/lib/copy/copy.component.scss
@@ -27,6 +27,7 @@
   $ripple-opacity: .4;
   $primary: darken(color(primary), 10%);
   $ripple-primary: rgba($primary, $ripple-opacity);
+  @include flex-container;
   display: block;
   max-width: 100%;
 
@@ -106,6 +107,7 @@
 .c-copy {
   // <div> Container for text content
   .c-copy__content {
+    @include flex-item(1, 1);
     @include hidden-scrollbars;
     align-items: center;
     justify-content: center;

--- a/libs/ui/copy/src/lib/ui-copy.module.ts
+++ b/libs/ui/copy/src/lib/ui-copy.module.ts
@@ -1,6 +1,6 @@
+import { ClipboardModule } from '@angular/cdk/clipboard';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 
 import { TsTooltipModule } from '@terminus/ui-tooltip';
 
@@ -10,8 +10,8 @@ export * from './copy/copy.component';
 
 @NgModule({
   imports: [
+    ClipboardModule,
     CommonModule,
-    FlexLayoutModule,
     TsTooltipModule,
   ],
   exports: [TsCopyComponent],

--- a/stories/ui-copy/copy.stories.ts
+++ b/stories/ui-copy/copy.stories.ts
@@ -1,4 +1,5 @@
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { action } from '@storybook/addon-actions';
 import {
   text,
   withKnobs,
@@ -30,13 +31,13 @@ export default {
 };
 
 export const basic = () => ({
-  template: `<ts-copy>{{ content }}</ts-copy>`,
+  template: `<ts-copy (copied)="didCopy($event)">{{ content }}</ts-copy>`,
   props: {
     content: text('Text to copy', URL_STANDARD),
+    didCopy: action('Text copied'),
   },
 });
 basic.parameters = {
-  actions: { disabled: true },
   docs: { iframeHeight: 180 },
 };
 

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -2,6 +2,6 @@ module.exports = {
   extends: '@terminus/stylelint-config-frontend',
   rules: {
     // Calc requires 'px'
-    'length-zero-no-unit': false,
+    'length-zero-no-unit': 0,
   },
 };

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,7 +1,12 @@
 module.exports = {
   extends: '@terminus/stylelint-config-frontend',
   rules: {
-    // Calc requires 'px'
-    'length-zero-no-unit': 0,
+    // TODO: remove once package is released
+    'length-zero-no-unit': [
+      true,
+      {
+        ignore: ['custom-properties'],
+      },
+    ],
   },
 };


### PR DESCRIPTION
- rewrite copy specs
- rely on CDK for clipboard functionality
- remove flex layout dependency
- now emits on copy
- update stylelint config to allow zero unit on custom props