### PR TITLE
feat(Sidenav): show/hide links and add Output emitters

### DIFF
--- a/libs/ui/sidenav/README.md
+++ b/libs/ui/sidenav/README.md
@@ -282,6 +282,19 @@ providers: [
 ],
 ```
 
+For Profile and SignOut, you can alternatively handle the click event directly
+within your app by binding to the proper EventEmitter output:
+
+```html
+<ts-sidenav
+  (profileClick)="onProfileClick()"
+  (signOutClick)="onSignOutClick()"
+></ts-sidenav>
+```
+
+Each link will only show if either a Route/URL is passed in or a listener
+is bound to the output emitter.
+
 <!-- Links -->
 [license-url]:         https://github.com/GetTerminus/terminus-oss/blob/release/LICENSE
 [license-image]:       http://img.shields.io/badge/license-MIT-blue.svg

--- a/libs/ui/sidenav/src/lib/sidenav/sidenav.component.html
+++ b/libs/ui/sidenav/src/lib/sidenav/sidenav.component.html
@@ -70,16 +70,18 @@
       </header>
       <hr>
       <ul>
-        <li>
-          <a [routerLink]="options.profileRoute">
+        <li *ngIf="options.profileRoute || isProfileClickBound">
+          <a [routerLink]="options.profileRoute"
+             (click)="profileClick.emit()">
             <span class="ts-sidenav-user__link-text">Profile</span>
             <span class="ts-sidenav-user__icon">
               <span class="fas fa-user"></span>
             </span>
           </a>
         </li>
-        <li><hr></li>
-        <li>
+        <li *ngIf="options.profileRoute || isProfileClickBound"><hr></li>
+
+        <li *ngIf="options.knowledgeBaseUrl">
           <a [href]="options.knowledgeBaseUrl">
             <span class="ts-sidenav-user__link-text"> {{ newSidenavDisplay ? 'Help Center' : 'Knowledge Base' }}</span>
             <span class="ts-sidenav-user__icon">
@@ -87,6 +89,7 @@
             </span>
           </a>
         </li>
+
         <li *ngIf="newSidenavDisplay && options.communityUrl">
           <a [href]="options.communityUrl">
             <span>Terminus Community</span>
@@ -95,7 +98,8 @@
             </span>
           </a>
         </li>
-        <li>
+
+        <li *ngIf="options.academyUrl">
           <a [href]="options.academyUrl">
             <span>Terminus Academy</span>
             <span class="ts-sidenav-user__icon">
@@ -103,9 +107,11 @@
             </span>
           </a>
         </li>
-        <li><hr></li>
-        <li>
-          <a [routerLink]="options.signOutRoute">
+
+        <li *ngIf="options.signOutRoute || isSignOutClickBound"><hr></li>
+        <li *ngIf="options.signOutRoute || isSignOutClickBound">
+          <a [routerLink]="options.signOutRoute"
+             (click)="signOutClick.emit()">
             <span>Sign Out</span>
             <span class="ts-sidenav-user__icon">
               <span class="fas fa-sign-out"></span>

--- a/libs/ui/sidenav/src/lib/sidenav/sidenav.component.ts
+++ b/libs/ui/sidenav/src/lib/sidenav/sidenav.component.ts
@@ -1,14 +1,7 @@
 import { ConnectionPositionPair } from '@angular/cdk/overlay';
 import type { CdkOverlayOrigin } from '@angular/cdk/overlay';
 import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  Inject,
-  InjectionToken,
-  Input,
-  Optional,
-  ViewChild,
+  ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -87,7 +80,7 @@ let nextUniqueId = 0;
   encapsulation: ViewEncapsulation.None,
   exportAs: 'tsSidenav',
 })
-export class TsSidenavComponent {
+export class TsSidenavComponent implements OnInit {
   /**
    * Define the default component UID
    */
@@ -187,7 +180,17 @@ export class TsSidenavComponent {
   }
   private _user: TS_SIDENAV_USER;
 
+  @Output() public readonly profileClick = new EventEmitter<void>();
+  @Output() public readonly signOutClick = new EventEmitter<void>();
+  public isProfileClickBound = false;
+  public isSignOutClickBound = false;
+
   constructor(
     public elementRef: ElementRef,
   ) {}
+
+  public ngOnInit() {
+    this.isProfileClickBound = this.profileClick.observers.length > 0;
+    this.isSignOutClickBound = this.signOutClick.observers.length > 0;
+  }
 }


### PR DESCRIPTION
feat(Sidenav): hide links with no handling, add emitters for custom Profile and SignOut handling

Add Output EventEmitters for consuming app to attach custom handling for Profile and SignOut links

Hide links that have no target or custom handlers bound.

ISSUES CLOSED: #569