### PR TITLE
feat(ts-sidenav): Add ProfileUrl option

### DIFF
--- a/libs/ui/sidenav/README.md
+++ b/libs/ui/sidenav/README.md
@@ -282,6 +282,9 @@ providers: [
 ],
 ```
 
+For Profile, you can alternatively pass in ProfileUrl which will be interpreted
+as an absolute URL rather than an internal application route.
+
 For Profile and SignOut, you can alternatively handle the click event directly
 within your app by binding to the proper EventEmitter output:
 

--- a/libs/ui/sidenav/package.json
+++ b/libs/ui/sidenav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terminus/ui-sidenav",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "author": "@terminus",
   "private": false,

--- a/libs/ui/sidenav/src/lib/sidenav/sidenav.component.html
+++ b/libs/ui/sidenav/src/lib/sidenav/sidenav.component.html
@@ -70,16 +70,25 @@
       </header>
       <hr>
       <ul>
-        <li *ngIf="options.profileRoute || isProfileClickBound">
-          <a [routerLink]="options.profileRoute"
-             (click)="profileClick.emit()">
+        <li *ngIf="options.profileRoute || options.profileUrl || isProfileClickBound">
+          <a *ngIf="options.profileUrl; else profileRouteOrClick"
+             [href]="options.profileUrl">
             <span class="ts-sidenav-user__link-text">Profile</span>
             <span class="ts-sidenav-user__icon">
               <span class="fas fa-user"></span>
             </span>
           </a>
+          <ng-template #profileRouteOrClick>
+            <a [routerLink]="options.profileRoute"
+              (click)="profileClick.emit()">
+              <span class="ts-sidenav-user__link-text">Profile</span>
+              <span class="ts-sidenav-user__icon">
+                <span class="fas fa-user"></span>
+              </span>
+            </a>
+          </ng-template>
         </li>
-        <li *ngIf="options.profileRoute || isProfileClickBound"><hr></li>
+        <li *ngIf="options.profileRoute || options.profileUrl || isProfileClickBound"><hr></li>
 
         <li *ngIf="options.knowledgeBaseUrl">
           <a [href]="options.knowledgeBaseUrl">

--- a/libs/ui/sidenav/src/lib/sidenav/sidenav.component.ts
+++ b/libs/ui/sidenav/src/lib/sidenav/sidenav.component.ts
@@ -24,6 +24,7 @@ export interface TS_SIDENAV_USER {
  */
 export interface TsSidenavDefaultOptions {
   profileRoute?: string;
+  profileUrl?: string;
   signOutRoute?: string;
   academyUrl?: string;
   knowledgeBaseUrl?: string;


### PR DESCRIPTION
When linking to an external profile url, use ProfileUrl instead of ProfileRoute