### PR TITLE
fix(ui-sidenav): Add markForCheck when isPanelOpen state changes

### DIFF
--- a/libs/ui/sidenav/src/lib/sidenav-trigger/sidenav-trigger.component.ts
+++ b/libs/ui/sidenav/src/lib/sidenav-trigger/sidenav-trigger.component.ts
@@ -219,7 +219,7 @@ export class TsSidenavTriggerComponent implements OnInit, OnDestroy {
   constructor(
     private renderer: Renderer2,
     public elementRef: ElementRef,
-    public cd: ChangeDetectorRef,
+    private readonly cd: ChangeDetectorRef,
     @Host() public hostSidenav: TsSidenavComponent,
   ) {}
 

--- a/libs/ui/sidenav/src/lib/sidenav-trigger/sidenav-trigger.component.ts
+++ b/libs/ui/sidenav/src/lib/sidenav-trigger/sidenav-trigger.component.ts
@@ -2,6 +2,7 @@ import { ConnectionPositionPair } from '@angular/cdk/overlay';
 import type { CdkOverlayOrigin } from '@angular/cdk/overlay';
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   Host,
@@ -176,6 +177,8 @@ export class TsSidenavTriggerComponent implements OnInit, OnDestroy {
     } else if (this.elementRef?.nativeElement?.classList.contains('ts-sidenav-trigger--open')) {
       this.renderer.removeClass(this.elementRef.nativeElement, 'ts-sidenav-trigger--open');
     }
+
+    this.cd.markForCheck();
   }
   public get isPanelOpen(): boolean {
     return this._isPanelOpen;
@@ -216,6 +219,7 @@ export class TsSidenavTriggerComponent implements OnInit, OnDestroy {
   constructor(
     private renderer: Renderer2,
     public elementRef: ElementRef,
+    public cd: ChangeDetectorRef,
     @Host() public hostSidenav: TsSidenavComponent,
   ) {}
 

--- a/specs/ui-sidenav/sidenav.component.spec.ts
+++ b/specs/ui-sidenav/sidenav.component.spec.ts
@@ -401,12 +401,14 @@ describe(`TsSidenavComponent`, function() {
       test(`should call markForCheck when isPanelOpen changes`, () => {
         const trigger = spectator.queryAll(TsSidenavTriggerComponent)[0];
 
+        // @ts-ignore
         trigger.cd.markForCheck = jest.fn();
 
         trigger.isPanelOpen = true;
 
         trigger.isPanelOpen = false;
 
+        // @ts-ignore
         expect(trigger.cd.markForCheck).toHaveBeenCalledTimes(2);
       });
 

--- a/specs/ui-sidenav/sidenav.component.spec.ts
+++ b/specs/ui-sidenav/sidenav.component.spec.ts
@@ -1,4 +1,5 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
+import { ChangeDetectorRef } from '@angular/core';
 import {
   FormControl,
   FormGroup,
@@ -395,6 +396,18 @@ describe(`TsSidenavComponent`, function() {
         trigger.isPanelOpen = true;
         spectator.detectChanges();
         expect(trigger.isPanelOpen).toEqual(true);
+      });
+
+      test(`should call markForCheck when isPanelOpen changes`, () => {
+        const trigger = spectator.queryAll(TsSidenavTriggerComponent)[0];
+
+        trigger.cd.markForCheck = jest.fn();
+
+        trigger.isPanelOpen = true;
+
+        trigger.isPanelOpen = false;
+
+        expect(trigger.cd.markForCheck).toHaveBeenCalledTimes(2);
       });
 
       test(`should focus the trigger if it is a button`, () => {


### PR DESCRIPTION
The TsSidenavTriggerComponent uses ChangeDetectionStrategy.OnPush strategy for change detection, but rely on the change of the _isPanelOpen attribute to control if the panel is open or not. 

This is not a problem when tha change of the attribute comes from within the component (the user action will trigger the change detection anyway), but when the attribute is changed from the outside of the component, the change does not trigger change detection.

This PR enables the component's consumers to close the drawer from the "outside".